### PR TITLE
o.c.o.converter: Handle invisible MessageButton.

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/Edm_activeMessageButtonClass.java
+++ b/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/Edm_activeMessageButtonClass.java
@@ -24,6 +24,7 @@ public class Edm_activeMessageButtonClass extends EdmWidget {
 	@EdmAttributeAn @EdmOptionalAn private String pressValue;
 	@EdmAttributeAn @EdmOptionalAn private String releaseValue;
 	@EdmAttributeAn @EdmOptionalAn private String password;
+	@EdmAttributeAn @EdmOptionalAn private boolean invisible;
 	
 	@EdmAttributeAn @EdmOptionalAn private boolean toggle;
 	
@@ -45,6 +46,10 @@ public class Edm_activeMessageButtonClass extends EdmWidget {
 
 	public String getReleaseValue() {
 		return releaseValue;
+	}
+
+	public boolean isInvisible() {
+		return invisible;
 	}
 
 

--- a/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeMessageButtonClass.java
+++ b/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeMessageButtonClass.java
@@ -31,13 +31,25 @@ public class Opi_activeMessageButtonClass extends OpiWidget {
 	 */
 	public Opi_activeMessageButtonClass(Context con, Edm_activeMessageButtonClass r) {
 		super(con, r);
-		setTypeId(typeId);
+		if (!r.isInvisible()) {
+			setTypeId(typeId);
+			new OpiBoolean(widgetContext, "show_led", false);
+			new OpiBoolean(widgetContext, "show_boolean_label", true);
+			new OpiBoolean(widgetContext, "square_button", true);
+			if (r.getControlPv() != null) {
+				createOnOffColorRule(r, "$(pv_name)", "background_color", r.getOnColor(),
+						r.getOffColor(), "OnOffBackgroundRule");
+			}
+		} else {
+			setTypeId("Rectangle");
+			new OpiBoolean(widgetContext, "transparent", true);
+			new OpiInt(widgetContext, "line_width", 0);
+		}
 		setName(name);
 		setVersion(version);
 
 		if (r.getControlPv() != null) {
-			createOnOffColorRule(r, convertPVName(r.getControlPv()), "background_color", r.getOnColor(),
-					r.getOffColor(), "OnOffBackgroundRule");
+			new OpiString(widgetContext, "pv_name", convertPVName(r.getControlPv()));
 			Element pvNameNode;
 			Element valueNode;
 			if(r.getPressValue()!=null){
@@ -45,16 +57,20 @@ public class Opi_activeMessageButtonClass extends OpiWidget {
 				pvNameNode.setTextContent(convertPVName(r.getControlPv()));
 				valueNode = widgetContext.getDocument().createElement("value");
 				valueNode.setTextContent(r.getPressValue());
+				// Hook actions to click in case of invisible rectangle, which can't 
+				// handle mouseDown and mouseUp separately.
 				new OpiAction(widgetContext, "WRITE_PV", Arrays.asList(pvNameNode, valueNode),
-						false, false);
+						true, true);
 			}
 			if (r.getReleaseValue() != null) {
 				pvNameNode = widgetContext.getDocument().createElement("pv_name");
 				pvNameNode.setTextContent(convertPVName(r.getControlPv()));
 				valueNode = widgetContext.getDocument().createElement("value");
 				valueNode.setTextContent(r.getReleaseValue());
+				// Hook actions to click in case of invisible rectangle, which can't 
+				// handle mouseDown and mouseUp separately.
 				new OpiAction(widgetContext, "WRITE_PV", Arrays.asList(pvNameNode, valueNode),
-						false, false);
+						true, true);
 			}
 			new OpiInt(widgetContext, "push_action_index", r.getPressValue()==null?1:0);
 			new OpiInt(widgetContext, "released_action_index", r.getPressValue()==null?0:1);
@@ -72,11 +88,6 @@ public class Opi_activeMessageButtonClass extends OpiWidget {
 		if (r.getPassword() != null)
 			new OpiString(widgetContext, "password", r.getPassword());
 		new OpiInt(widgetContext, "show_confirm_dialog", r.getPassword() != null ? 1 : 0);
-
-		new OpiBoolean(widgetContext, "show_led", false);
-		new OpiBoolean(widgetContext, "show_boolean_label", true);
-		new OpiBoolean(widgetContext, "square_button", true);
-
 	}
 
 	/**


### PR DESCRIPTION
This is incomplete, since there is no widget in CSS that can both:

* handle separate mouseDown and mouseUp events
* be invisible.

This commit is a compromise, since I don't think any of our invisible
MessageButtons require the mouseUp functionality.