### PR TITLE
CSS-151: Support right click Show/Hide on OPIShell Graph toolbar

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -81,6 +81,8 @@ public final class OPIShell implements IOPIRuntime {
 
     private static Logger log = OPIBuilderPlugin.getLogger();
     public static final String OPI_SHELLS_CHANGED_ID = "org.csstudio.opibuilder.opiShellsChanged";
+    // The active OPIshell, or null if no OPIShell is active
+    public static OPIShell activeShell = null;
     // Cache of open OPI shells in order of opening.
     private static final Set<OPIShell> openShells = new LinkedHashSet<OPIShell>();
     // The view against which the context menu is registered.
@@ -142,7 +144,9 @@ public final class OPIShell implements IOPIRuntime {
             private boolean firstRun = true;
             public void shellIconified(ShellEvent e) {}
             public void shellDeiconified(ShellEvent e) {}
-            public void shellDeactivated(ShellEvent e) {}
+            public void shellDeactivated(ShellEvent e) {
+                activeShell = null;
+            }
             public void shellClosed(ShellEvent e) {
                 // Remove this shell from the cache.
                 openShells.remove(OPIShell.this);
@@ -156,6 +160,7 @@ public final class OPIShell implements IOPIRuntime {
                     shell.setFocus();
                     firstRun = false;
                 }
+                activeShell = OPIShell.this;
             }
         });
         shell.addDisposeListener(new DisposeListener() {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -405,7 +405,7 @@ public final class OPIShell implements IOPIRuntime {
         throw new NotImplementedException();
     }
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public Object getAdapter(Class adapter) {
         if (adapter == ActionRegistry.class)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -31,6 +31,7 @@ import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.gef.tools.DragEditPartsTracker;
 import org.eclipse.gef.ui.actions.ActionRegistry;
@@ -411,6 +412,8 @@ public final class OPIShell implements IOPIRuntime {
             return this.actionRegistry;
         if (adapter == GraphicalViewer.class)
             return this.viewer;
+        if (adapter == CommandStack.class)
+            return this.viewer.getEditDomain().getCommandStack();
         return null;
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
@@ -185,6 +185,15 @@ public class OPIShellSummary extends FXViewPart {
         cachedShells = updatedShells;
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public Object getAdapter(Class adapter) {
+        if(OPIShell.activeShell == null) {
+            return null;
+        }
+        return OPIShell.activeShell.getAdapter(adapter);
+    }
+
     @Override
     public String toString() {
         return "OpiShell summary: " + getViewSite().getId();


### PR DESCRIPTION
This allows the right click menu options on an OPIShell to propagate through to the underlying widgets by implementing getAdapter correctly.

In order to choose the correct shell to call getAdapter on the OPIShell remembers which shell is active, and the OPIShellSummary checks this and calls getAdapter on the active shell.