### PR TITLE
o.c.opibuilder: use generics to remove casts.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/SelectParentHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/SelectParentHandler.java
@@ -29,12 +29,12 @@ public class SelectParentHandler extends AbstractHandler {
 
     public Object execute(ExecutionEvent event) throws ExecutionException {
 
-        Object viewer = HandlerUtil.getActivePart(event).getAdapter(
+        GraphicalViewer viewer = HandlerUtil.getActivePart(event).getAdapter(
                 GraphicalViewer.class);
         if (viewer == null)
             return null;
 
-        ISelection currentSelection = ((GraphicalViewer) viewer).getSelection();
+        ISelection currentSelection = viewer.getSelection();
 
         if (currentSelection instanceof IStructuredSelection) {
             Object element = ((IStructuredSelection) currentSelection)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/actions/SendEMailAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/actions/SendEMailAction.java
@@ -40,8 +40,7 @@ public class SendEMailAction extends AbstractSendEMailAction
     {
         try
         {
-            return ResourceUtil.getScreenshotFile(
-                    (GraphicalViewer) opiRuntime.getAdapter(GraphicalViewer.class));
+            return ResourceUtil.getScreenshotFile(opiRuntime.getAdapter(GraphicalViewer.class));
         }
         catch (Exception ex)
         {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/actions/SendToElogAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/actions/SendToElogAction.java
@@ -70,8 +70,7 @@ public class SendToElogAction extends Action {
                         final String filename;
                         try {
                             filename = ResourceUtil
-                                    .getScreenshotFile((GraphicalViewer) opiRuntime
-                                            .getAdapter(GraphicalViewer.class));
+                                    .getScreenshotFile(opiRuntime.getAdapter(GraphicalViewer.class));
                         } catch (Exception ex) {
                             MessageDialog.openError(opiRuntime.getSite()
                                     .getShell(), "error", ex.getMessage());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -405,15 +405,14 @@ public final class OPIShell implements IOPIRuntime {
         throw new NotImplementedException();
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Object getAdapter(Class adapter) {
+    public <T> T getAdapter(Class<T> adapter) {
         if (adapter == ActionRegistry.class)
-            return this.actionRegistry;
+            return adapter.cast(this.actionRegistry);
         if (adapter == GraphicalViewer.class)
-            return this.viewer;
+            return adapter.cast(this.viewer);
         if (adapter == CommandStack.class)
-            return this.viewer.getEditDomain().getCommandStack();
+            return adapter.cast(this.viewer.getEditDomain().getCommandStack());
         return null;
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
@@ -185,9 +185,8 @@ public class OPIShellSummary extends FXViewPart {
         cachedShells = updatedShells;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Object getAdapter(Class adapter) {
+    public <T> T getAdapter(Class<T> adapter) {
         if(OPIShell.activeShell == null) {
             return null;
         }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/LockUnlockChildrenHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/LockUnlockChildrenHandler.java
@@ -26,16 +26,16 @@ public class LockUnlockChildrenHandler extends AbstractHandler {
 
     public Object execute(ExecutionEvent event) throws ExecutionException {
 
-            Object viewer = HandlerUtil.getActivePart(event).getAdapter(GraphicalViewer.class);
+            GraphicalViewer viewer = HandlerUtil.getActivePart(event).getAdapter(GraphicalViewer.class);
             if(viewer == null) return null;
 
-            ISelection currentSelection =((GraphicalViewer)viewer).getSelection();
+            ISelection currentSelection = viewer.getSelection();
             if(currentSelection instanceof IStructuredSelection){
                 Object element = ((IStructuredSelection) currentSelection)
                         .getFirstElement();
                 if(element instanceof GroupingContainerEditPart){
                     CommandStack commandStack =
-                        (CommandStack) (HandlerUtil.getActivePart(event)).getAdapter(CommandStack.class);
+                        HandlerUtil.getActivePart(event).getAdapter(CommandStack.class);
                     if(commandStack != null)
                         commandStack.execute(LockUnlockChildrenAction.createLockUnlockCommand
                                 (((GroupingContainerEditPart)element).getWidgetModel()));

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextEditManager.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextEditManager.java
@@ -144,7 +144,7 @@ private void disposeScaledFont() {
 
 protected void initCellEditor() {
     // update text
-    ITextFigure textFigure = (ITextFigure) getEditPart().getAdapter(ITextFigure.class);
+    ITextFigure textFigure = getEditPart().getAdapter(ITextFigure.class);
 
 //    AbstractWidgetModel labelModel = (AbstractWidgetModel) getEditPart().getModel();
     getCellEditor().setValue(textFigure.getText());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/GroupingContainerFeedbackFactory.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/GroupingContainerFeedbackFactory.java
@@ -99,8 +99,7 @@ public class GroupingContainerFeedbackFactory extends DefaultGraphicalFeedbackFa
                         IWorkbenchPart activePart = PlatformUI.getWorkbench().
                                 getActiveWorkbenchWindow().getActivePage().getActivePart();
 
-                        CommandStack commandStack =
-                                (CommandStack)activePart.getAdapter(CommandStack.class);
+                        CommandStack commandStack = activePart.getAdapter(CommandStack.class);
                             if(commandStack != null)
                                 commandStack.execute(LockUnlockChildrenAction.createLockUnlockCommand
                                         (((GroupingContainerEditPart)getOwner()).getWidgetModel()));

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PointListCreationTool.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PointListCreationTool.java
@@ -189,8 +189,7 @@ public final class PointListCreationTool extends TargetingTool {
     @Override
     protected boolean handleButtonDown(final int button) {
         if (getTargetEditPart() != null) {
-            _snap2Helper = (SnapToHelper) getTargetEditPart().getAdapter(
-                    SnapToHelper.class);
+            _snap2Helper = getTargetEditPart().getAdapter(SnapToHelper.class);
         }
 
         // only react on left clicks

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PolyPointDragTracker.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PolyPointDragTracker.java
@@ -107,8 +107,7 @@ public final class PolyPointDragTracker extends SimpleDragTracker {
         _oldPoints = ((Polyline) _owner.getFigure()).getPoints().getCopy();
 
         if (getTargetEditPart() != null) {
-            _snapToHelper = (SnapToHelper) getTargetEditPart().getAdapter(
-                    SnapToHelper.class);
+            _snapToHelper = getTargetEditPart().getAdapter(SnapToHelper.class);
         }
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/AbstractWidgetTargetAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/AbstractWidgetTargetAction.java
@@ -55,7 +55,7 @@ public abstract class AbstractWidgetTargetAction  implements IObjectActionDelega
      * @return the command stack
      */
     protected CommandStack getCommandStack() {
-        return (CommandStack)targetPart.getAdapter(CommandStack.class);
+        return targetPart.getAdapter(CommandStack.class);
     }
 
     public void selectionChanged(IAction action, ISelection selection) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/PartZoomAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/PartZoomAction.java
@@ -54,7 +54,7 @@ abstract class PartZoomAction extends Action implements ZoomListener, Disposable
         this.part = part;
         if(zoomManager != null)
             zoomManager.removeZoomListener(this);
-        ZoomManager newZoomManager = (ZoomManager)part.getAdapter(ZoomManager.class);
+        ZoomManager newZoomManager = part.getAdapter(ZoomManager.class);
         if(newZoomManager != null){
             newZoomManager.addZoomListener(this);
             zoomManager = newZoomManager;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/PrintDisplayAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/PrintDisplayAction.java
@@ -72,8 +72,7 @@ public class PrintDisplayAction extends WorkbenchPartAction {
      */
     public void run() {
         final GraphicalViewer viewer;
-        viewer = (GraphicalViewer) getWorkbenchPart().getAdapter(
-                GraphicalViewer.class);
+        viewer = getWorkbenchPart().getAdapter(GraphicalViewer.class);
 
         viewer.getControl().getDisplay().asyncExec(new Runnable() {
             @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/DisplayOpenManager.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/DisplayOpenManager.java
@@ -64,13 +64,13 @@ public class DisplayOpenManager {
         if(input instanceof IRunnerInput){
             if(((IRunnerInput)input).getDisplayOpenManager() == null)
                 ((IRunnerInput)input).setDisplayOpenManager(
-                    (DisplayOpenManager)opiRuntime.getAdapter(DisplayOpenManager.class));
+                    opiRuntime.getAdapter(DisplayOpenManager.class));
             return (IRunnerInput)input;
         }
 
         else
             return new RunnerInput(getCurrentPathInEditor(),
-                    (DisplayOpenManager)opiRuntime.getAdapter(DisplayOpenManager.class));
+                    opiRuntime.getAdapter(DisplayOpenManager.class));
 
 
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRuntimeDelegate.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRuntimeDelegate.java
@@ -482,22 +482,21 @@ public class OPIRuntimeDelegate implements IAdaptable{
         job.schedule();
     }
 
-    @SuppressWarnings("rawtypes")
-    public Object getAdapter(Class adapter) {
+    public <T> T getAdapter(Class<T> adapter) {
         if (adapter == DisplayOpenManager.class) {
             if (displayOpenManager == null)
                 displayOpenManager = new DisplayOpenManager(opiRuntime);
-            return displayOpenManager;
+            return adapter.cast(displayOpenManager);
         }
         if (adapter == GraphicalViewer.class)
-            return viewer;
+            return adapter.cast(viewer);
         if (adapter == ActionRegistry.class)
-            return getActionRegistry();
+            return adapter.cast(getActionRegistry());
         if (adapter == CommandStack.class)
-            return viewer.getEditDomain().getCommandStack();
+            return adapter.cast(viewer.getEditDomain().getCommandStack());
         if (adapter == ZoomManager.class)
-            return ((ScalableFreeformRootEditPart) viewer.getRootEditPart())
-                    .getZoomManager();
+            return adapter.cast(((ScalableFreeformRootEditPart) viewer.getRootEditPart())
+                    .getZoomManager());
         return null;
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRuntimeToolBarDelegate.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRuntimeToolBarDelegate.java
@@ -69,16 +69,14 @@ public class OPIRuntimeToolBarDelegate{
         partZoomInAction.setPart(opiRuntime);
         partZoomOutAction.setPart(opiRuntime);
         partZoomComboContributionItem.setPart(opiRuntime);
-        DisplayOpenManager manager =
-            (DisplayOpenManager)opiRuntime.getAdapter(DisplayOpenManager.class);
+        DisplayOpenManager manager = opiRuntime.getAdapter(DisplayOpenManager.class);
         backwardAction.setDisplayOpenManager(manager);
         forwardAction.setDisplayOpenManager(manager);
         IActionBars bars = getActionBars();
         bars.setGlobalActionHandler(backwardAction.getId(), backwardAction);
         bars.setGlobalActionHandler(forwardAction.getId(), forwardAction);
 
-        ActionRegistry actionRegistry =
-            (ActionRegistry) opiRuntime.getAdapter(ActionRegistry.class);
+        ActionRegistry actionRegistry = opiRuntime.getAdapter(ActionRegistry.class);
         bars.setGlobalActionHandler(ActionFactory.PRINT.getId(),
                 actionRegistry.getAction(ActionFactory.PRINT.getId()));
         bars.setGlobalActionHandler(ActionFactory.REFRESH.getId(),

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/RunModeService.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/RunModeService.java
@@ -97,7 +97,7 @@ public class RunModeService
                     mode = DisplayMode.NEW_TAB;
                 else
                 {   // Replace display in current runtime
-                    final DisplayOpenManager manager = (DisplayOpenManager) runtime.get().getAdapter(DisplayOpenManager.class);
+                    final DisplayOpenManager manager = runtime.get().getAdapter(DisplayOpenManager.class);
                     if (manager != null) {
                         manager.openNewDisplay();
                     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/PartZoomComboContributionItem.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/PartZoomComboContributionItem.java
@@ -281,7 +281,7 @@ public class PartZoomComboContributionItem extends ContributionItem implements
         if(this.part == part)
             return;
         this.part = part;
-        ZoomManager newZoomManager = (ZoomManager)part.getAdapter(ZoomManager.class);
+        ZoomManager newZoomManager = part.getAdapter(ZoomManager.class);
         if(newZoomManager != null){
             setZoomManager(newZoomManager);
         }


### PR DESCRIPTION
This uses the updated implementation of IAdaptable in Mars.
It also allows removal of SuppressWarnings annotations.