### PR TITLE
Catch and remove any un-disposed OPIShells.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -168,7 +168,13 @@ public final class OPIShell implements IOPIRuntime {
 
             @Override
             public void widgetDisposed(DisposeEvent e) {
-                if (!icon.isDisposed()) icon.dispose();
+                if (!icon.isDisposed()) {
+                    icon.dispose();
+                }
+                if (openShells.contains(OPIShell.this)) {
+                    log.warning("Disposed shell not removed by shellClosed()");
+                    openShells.remove(OPIShell.this);
+                }
             }
         });
         /*
@@ -457,4 +463,7 @@ public final class OPIShell implements IOPIRuntime {
         return Objects.hash(OPIShell.class, macrosInput, path);
     }
 
+    public boolean isDisposed() {
+        return ((shell == null) || (shell.isDisposed()));
+    }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
@@ -8,7 +8,9 @@
 package org.csstudio.opibuilder.runmode;
 
 import java.util.Set;
+import java.util.logging.Logger;
 
+import org.csstudio.opibuilder.OPIBuilderPlugin;
 import org.eclipse.fx.ui.workbench3.FXViewPart;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IViewSite;
@@ -39,6 +41,7 @@ import javafx.scene.layout.VBox;
 public class OPIShellSummary extends FXViewPart {
 
     public static final String ID = "org.csstudio.opibuilder.opiShellSummary";
+    private static Logger log = OPIBuilderPlugin.getLogger();
 
     private ScrollPane scrollpane;
     private GridPane grid;
@@ -155,6 +158,10 @@ public class OPIShellSummary extends FXViewPart {
             summaryLabel.setText("There " + isAre + " " + updatedShells.size() + " standalone OPI" + plural + " open.");
             // Register right-click with any new shells.
             for (OPIShell shell : updatedShells) {
+                if (shell.isDisposed()) {
+                    log.warning("Summary view ignoring disposed shell.");
+                    continue;
+                }
                 if ( ! cachedShells.contains(shell)) {
                     shell.registerWithView(this);
                 }


### PR DESCRIPTION
Occasionally an OPIShell can be disposed without being removed from
the cache by the shellClosed() method. Catch these occasions and log
a warning.

@nickbattam this isn't the final version I'll push back - it has extra logging so that we can see what's happening.