### PR TITLE
Default useParentMacros to true in OpenDisplayAction

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/widgetActions/OpenDisplayAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/widgetActions/OpenDisplayAction.java
@@ -224,7 +224,7 @@ public class OpenDisplayAction extends AbstractWidgetAction
     protected MacrosInput getMacrosInput()
     {
         MacrosInput result = new MacrosInput(
-                new LinkedHashMap<String, String>(), false);
+                new LinkedHashMap<String, String>(), true);
 
         MacrosInput macrosInput = ((MacrosInput) getPropertyValue(PROP_MACROS))
                 .getCopy();


### PR DESCRIPTION
Otherwise it is inconsistent with the behaviour in
ExternalDisplayAction.