### PR TITLE
Default useParentMacros to true in OPIShell.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -263,11 +263,12 @@ public final class OPIShell implements IOPIRuntime {
      *************************************************************/
 
     /**
-     * This is the only way to create an OPIShell
+     * This is the only way to create an OPIShell.
+     * Logs an error and cleans up if path is null.
      */
     public static void openOPIShell(IPath path, MacrosInput macrosInput) {
         if (macrosInput == null) {
-            macrosInput = new MacrosInput(new LinkedHashMap<String, String>(), false);
+            macrosInput = new MacrosInput(new LinkedHashMap<String, String>(), true);
         }
         boolean alreadyOpen = false;
         for (OPIShell opiShell : openShells) {


### PR DESCRIPTION
Otherwise it is inconsistent with the behaviour in
ExternalDisplayAction.