### PR TITLE
Add engineering number format (integration)

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_TextupdateClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_TextupdateClass.java
@@ -50,9 +50,10 @@ public class Opi_TextupdateClass extends OpiWidget {
         // Handle format and units
         boolean precisionFromPV = true;
         boolean showUnits = true;
+        // Mode maps to org.csstudio.simplepv.FormatEnum
         int mode = 0; // show default display
         if(t.getDisplayMode() == null){ // default mode in EDM; ignores precision field and shows units
-            mode = 0;
+            mode = 0;  // DEFAULT
             precisionFromPV = true;
             showUnits = true;
         } else { // not default mode in EDM
@@ -60,11 +61,13 @@ public class Opi_TextupdateClass extends OpiWidget {
             precisionFromPV = false;
             showUnits = false;
             if(t.getDisplayMode().equals("decimal")){
-                mode = 1;
-            } else if(t.getDisplayMode().equals("engineer") || t.getDisplayMode().equals("exp")) {
-                mode = 2;
-            } else if(t.getDisplayMode().equals("hex")) {
-                mode = 3;
+                mode = 1;  // DECIMAL
+            } else if (t.getDisplayMode().equals("exp")) {
+                mode = 2;  // EXP
+            } else if (t.getDisplayMode().equals("hex")) {
+                mode = 3;  // HEX32
+            } else if (t.getDisplayMode().equals("engineer")){
+                mode = 7;  // ENG
             }
         }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.classpath
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.project
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.csstudio.simplepv.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Fragment of org.csstudio.simplepv
+Bundle-SymbolicName: org.csstudio.simplepv.test
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: org.csstudio.simplepv;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.junit,
+ org.csstudio.utility.test;bundle-version="1.0.0"
+Import-Package: org.csstudio.simplepv

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/build.properties
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.csstudio</groupId>
+    <artifactId>opibuilder-plugins</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.csstudio.simplepv.test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+</project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeFormatTest.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeFormatTest.java
@@ -1,0 +1,122 @@
+package org.csstudio.simplepv;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import static org.hamcrest.CoreMatchers.*;
+
+import org.diirt.vtype.VType;
+import org.diirt.vtype.ValueFactory;
+import org.junit.Test;
+
+
+public class VTypeFormatTest {
+
+    VType longValue = ValueFactory.newVLong(Long.valueOf(4294906129L), ValueFactory.alarmNone(),
+            ValueFactory.timeNow(), ValueFactory.displayNone());
+    VType intValue = ValueFactory.newVInt(4003, ValueFactory.alarmNone(),
+            ValueFactory.timeNow(), ValueFactory.displayNone());
+    VType intForStringValue = ValueFactory.newVInt(97, ValueFactory.alarmNone(),
+            ValueFactory.timeNow(), ValueFactory.displayNone());
+    VType smallDoubleValue =  ValueFactory.newVDouble(1.234567e-7);
+    VType doubleNaNValue =  ValueFactory.newVDouble(Double.NaN);
+    VType doubleInfValue =  ValueFactory.newVDouble(Double.POSITIVE_INFINITY);
+    VType smallNegativeDoubleValue =  ValueFactory.newVDouble(-1.234567e-7);
+    VType bigDoubleValue =  ValueFactory.newVDouble(6.54321e23);
+    VType orderTenDoubleValue =  ValueFactory.newVDouble(21.251235);
+
+    @Test
+    public void expFormatValueOfSmallDoubleWithPrecisionMinus1IsExpWith4dp() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.EXP, smallDoubleValue, -1), is("1.2346E-7"));
+    }
+
+    @Test
+    public void expFormatValueOfSmallDoubleWithPrecision2IsExpWith2dp() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.EXP, smallDoubleValue, 2), is("1.23E-7"));
+    }
+
+    @Test
+    public void expFormatValueOfDoubleHasCharacteristicLtTen() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.EXP, orderTenDoubleValue, -1), is("2.1251E1"));
+    }
+
+    @Test
+    public void expFormatValueOfBigDoubleHasCorrectPositiveExponent() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.EXP, bigDoubleValue, -1), is("6.5432E23"));
+    }
+
+    @Test
+    public void hexFormatValueOfIntegerIsUpperCaseHexWithPrefix() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.HEX, intValue, 1), is("0xFA3"));
+    }
+
+    @Test
+    public void hexFormatValueOfLongIsUpperCaseHexWithPrefix() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.HEX, longValue, 1), is("0xFFFF1111"));
+    }
+
+    @Test
+    public void hex64FormatValueOfLongIsLowerCaseHexWithPrefix() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.HEX64, longValue, 1), is("0xffff1111"));
+    }
+
+    @Test
+    public void stringFormatValueOfIntegerIsCharacter() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.STRING, intForStringValue, 1), is("a"));
+    }
+
+    @Test
+    public void engFormatValueOfSmallDoubleWithDefaultPrecisionHasCharacteristicLtThousand() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.ENG, smallDoubleValue, -1), is("123.4567E-9"));
+    }
+
+    @Test
+    public void engFormatValueOfSmallNegativeDoubleWithPrecisionTwoHasTwoDP() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.ENG, smallNegativeDoubleValue, 2), is("-123.46E-9"));
+    }
+
+    @Test
+    public void engFormatValueOfDoubleHasExponentPowerOfThreeSpreadOfExponents() {
+
+        for (int i=-324; i < 308; i++) {
+            VType value =  ValueFactory.newVDouble(Double.parseDouble(String.format("1.234567e%d", i)));
+            String[] parts = VTypeHelper.formatValue(FormatEnum.ENG, value, 2).toUpperCase().split("E");
+            try {
+                int actualExponent = Integer.parseInt(parts[1]);
+                assertThat(String.format("%d -> %sE%s", i, parts[0], parts[1]), actualExponent % 3, is(0));
+            }
+            catch (NumberFormatException ex) {
+                fail(String.format("Non numeric exponent for %d", i));
+            }
+        }
+    }
+    @Test
+    public void decFormatValueOfDoubleInftyisInfty() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, doubleInfValue, 3), is("Infinity"));
+    }
+
+    @Test
+    public void decFormatValueOfDoubleNaNisDoubleNaNForSetPrecision() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, doubleNaNValue, 3), is("NaN"));
+    }
+
+    @Test
+    public void decFormatValueOfDoubleNaNisDoubleNaNForUnsetPrecision() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, doubleNaNValue, -1), is("NaN"));
+    }
+
+    @Test
+    public void decFormatValueOfbigDoubleHasPrecisionDecimalPlaces() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, bigDoubleValue, 3), is("654321000000000000000000.000"));
+    }
+
+    @Test
+    public void decFormatValueOfsmallDoubleHasPrecisionDecimalPlaces() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, smallNegativeDoubleValue, 2), is("-0.00"));
+    }
+
+    @Test
+    public void decFormatValueOfDoubleHasFullValueForUnsetPrecision() {
+        assertThat(VTypeHelper.formatValue(FormatEnum.DECIMAL, orderTenDoubleValue, -1), is("21.251235"));
+    }
+}

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeHelperBean.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeHelperBean.java
@@ -1,0 +1,15 @@
+package org.csstudio.simplepv;
+
+public class VTypeHelperBean {
+
+    BasicDataType btype;
+    Double dval;
+    boolean isScalar;
+
+    public VTypeHelperBean(BasicDataType expectedType, Double dval, boolean isScalar) {
+        this.btype = expectedType;
+        this.dval = dval;
+        this.isScalar = true;
+    }
+}
+

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeHelperTest.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/src/org/csstudio/simplepv/VTypeHelperTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.simplepv;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.diirt.vtype.VType;
+import org.diirt.vtype.ValueFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/** JUnit test for VTypeHelper methods
+ *
+ *  @author Nick Battam
+ */
+@RunWith(Parameterized.class)
+public class VTypeHelperTest
+{
+
+    private VType testValue;
+    private VTypeHelperBean expectedData;
+
+    public VTypeHelperTest(VType value, VTypeHelperBean data) {
+        this.testValue = value;
+        this.expectedData = data;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> vtypeInstances() {
+       return Arrays.asList(new Object[][] {
+          { null,
+               new VTypeHelperBean(BasicDataType.UNKNOWN, Double.NaN, true) },
+          { ValueFactory.newVByte(new Byte("4"),
+                   ValueFactory.alarmNone(),
+                   ValueFactory.timeNow(),
+                   ValueFactory.displayNone()),
+               new VTypeHelperBean(BasicDataType.BYTE, 4.0, true)},
+          { ValueFactory.newVDouble(1.0),
+               new VTypeHelperBean(BasicDataType.DOUBLE, 1.0, true)},
+          { ValueFactory.newVEnum(1, Arrays.asList(new String[] {"zero", "one"}),
+                  ValueFactory.alarmNone(),
+                  ValueFactory.timeNow()),
+               new VTypeHelperBean(BasicDataType.ENUM, 1.0, true) },
+          { ValueFactory.newVFloat(0.5f,
+                  ValueFactory.alarmNone(),
+                  ValueFactory.timeNow(),
+                  ValueFactory.displayNone()),
+               new VTypeHelperBean(BasicDataType.FLOAT, 0.5, true) },
+          { ValueFactory.newVInt(42,
+                  ValueFactory.alarmNone(),
+                  ValueFactory.timeNow(),
+                  ValueFactory.displayNone()),
+               new VTypeHelperBean(BasicDataType.INT, 42.0, true) },
+          { ValueFactory.newVShort(new Short("21"),
+                  ValueFactory.alarmNone(),
+                  ValueFactory.timeNow(),
+                  ValueFactory.displayNone()),
+              new VTypeHelperBean(BasicDataType.SHORT, 21.0, true) },
+          { ValueFactory.newVString("test",
+                  ValueFactory.alarmNone(),
+                  ValueFactory.timeNow()),
+              new VTypeHelperBean(BasicDataType.STRING, Double.NaN, true) },
+       });
+    }
+
+    @Test
+    public void getBasicTypeDataTest() {
+        assertThat(VTypeHelper.getBasicDataType(testValue), is(expectedData.btype));
+    }
+
+    @Test
+    public void getDoubleReturnsDoubleReprOfValueIfNotSTRINGorUNKNOWN() {
+        if (expectedData.btype != BasicDataType.UNKNOWN &&
+                expectedData.btype != BasicDataType.STRING) {
+            assertThat(VTypeHelper.getDouble(testValue), is(expectedData.dval));
+        }
+    }
+
+    @Test
+    public void getDoubleReturnsNaNIfTypeUNKNOWN() {
+        if (expectedData.btype == BasicDataType.UNKNOWN) {
+            assertThat(VTypeHelper.getDouble(testValue), is(Double.NaN));
+        }
+    }
+
+    @Test
+    public void getDoubleReturnsNaNIfTypeSTRING() {
+        if (expectedData.btype == BasicDataType.STRING) {
+            assertThat(VTypeHelper.getDouble(testValue), is(Double.NaN));
+        }
+    }
+
+    @Test
+    public void getSizeIsOneForScalarOtherwiseArrayLength() {
+        if (expectedData.isScalar) {
+            assertThat(VTypeHelper.getSize(testValue), is(1));
+        }
+    }
+
+}

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/FormatEnum.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/FormatEnum.java
@@ -36,7 +36,11 @@ public enum FormatEnum {
      * based on the value digits to make sure the string won't be too long. The recommended
      * digits is 4.
      */
-    COMPACT("Compact");
+    COMPACT("Compact"),
+    /**
+     * Engineering format (exponent is power of three). For example, 20.23E9
+     */
+    ENG("Engineering");
 
     private String description;
     private FormatEnum(String description) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
@@ -442,6 +442,7 @@ public class VTypeHelper {
         case DECIMAL:
         case EXP:
         case COMPACT:
+        case ENG:
             return Integer.toString(enumValue.getIndex());
         case HEX:
         case HEX64:
@@ -470,6 +471,9 @@ public class VTypeHelper {
             Number numValue, int precision) {
         if (pmValue != null)
             numValue = (Number) ((Scalar) pmValue).getValue();
+
+        NumberFormat numberFormat;
+
         switch (formatEnum) {
         case DECIMAL:
         case DEFAULT:
@@ -493,7 +497,7 @@ public class VTypeHelper {
                         return Double.toString(numValue.doubleValue());
                     }
 
-                    NumberFormat numberFormat = formatCacheMap.get(precision);
+                    numberFormat = formatCacheMap.get(precision);
                     if (numberFormat == null) {
                         numberFormat = new DecimalFormat("0"); //$NON-NLS-1$
                         numberFormat.setMinimumFractionDigits(precision);
@@ -513,17 +517,33 @@ public class VTypeHelper {
             } else {
                 return formatScalarNumber(FormatEnum.EXP, numValue, precision == -1 ? 4 : precision);
             }
+
+        case ENG:
+            double value = numValue.doubleValue();
+            if (value == 0) {
+                return formatScalarNumber(FormatEnum.EXP, numValue, precision == -1 ? 4 : precision);
+            }
+
+            if (precision == -1 && numValue instanceof Display) {
+                precision = ((Display) numValue).getFormat().getMinimumFractionDigits();
+            }
+            if (precision == -1)
+                precision = DEFAULT_PRECISION;
+
+            double log10 = Math.log10(Math.abs(value));
+            int power = 3 * (int) Math.floor(log10 / 3);
+            return String.format("%." + precision + "fE%d", value / Math.pow(10, power), power);
+
         case EXP:
             if (precision == -1 && numValue instanceof Display) {
                 precision = ((Display) numValue).getFormat().getMinimumFractionDigits();
             }
-            NumberFormat numberFormat;
             if (precision == -1)
                 precision = DEFAULT_PRECISION;
 
             // Assert positive precision
             precision = Math.abs(precision);
-            // Exponential notation itentified as 'negative' precision in cached
+            // Exponential notation identified as 'negative' precision in cached
             numberFormat = formatCacheMap.get(-precision);
             if (numberFormat == null) {
                 final StringBuffer pattern = new StringBuffer(10);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
@@ -50,6 +50,7 @@ import org.diirt.vtype.ValueUtil;
 public class VTypeHelper {
 
     public static final int DEFAULT_PRECISION = 4;//$NON-NLS-1$
+    public static final int UNSET_PRECISION = -1;//$NON-NLS-1$
     public static final String HEX_PREFIX = "0x"; //$NON-NLS-1$
     /**
      * The max count of values to be formatted into string. The value beyond
@@ -478,34 +479,34 @@ public class VTypeHelper {
         case DECIMAL:
         case DEFAULT:
         default:
-            if (precision == -1 && pmValue != null && pmValue instanceof Display
-                    && ((Display) pmValue).getFormat() != null) {
-                return ((Display) pmValue).getFormat().format(((Number) numValue).doubleValue());
-            } else {
-                if (precision == -1)
+            if (precision == UNSET_PRECISION) {
+                if (pmValue instanceof Display && ((Display) pmValue).getFormat() != null) {
+                    return ((Display) pmValue).getFormat().format(((Number) numValue).doubleValue());
+                } else {
                     return formatScalarNumber(FormatEnum.COMPACT, numValue, precision);
-                else {
-                    // Sun's implementation of the JDK returns the Unicode replacement
-                    // character, U+FFFD, when asked to parse a NaN. This is more
-                    // consistent with the rest of CSS.
-                    if(Double.isNaN(numValue.doubleValue())) {
-                        return Double.toString(Double.NaN);
-                    }
-
-                    // Also check for positive and negative infinity.
-                    if(Double.isInfinite(numValue.doubleValue())) {
-                        return Double.toString(numValue.doubleValue());
-                    }
-
-                    numberFormat = formatCacheMap.get(precision);
-                    if (numberFormat == null) {
-                        numberFormat = new DecimalFormat("0"); //$NON-NLS-1$
-                        numberFormat.setMinimumFractionDigits(precision);
-                        numberFormat.setMaximumFractionDigits(precision);
-                        formatCacheMap.put(precision, numberFormat);
-                    }
-                    return numberFormat.format(numValue.doubleValue());
                 }
+
+            } else {
+                // Sun's implementation of the JDK returns the Unicode replacement
+                // character, U+FFFD, when asked to parse a NaN. This is more
+                // consistent with the rest of CSS.
+                if(Double.isNaN(numValue.doubleValue())) {
+                    return Double.toString(Double.NaN);
+                }
+
+                // Also check for positive and negative infinity.
+                if(Double.isInfinite(numValue.doubleValue())) {
+                    return Double.toString(numValue.doubleValue());
+                }
+
+                numberFormat = formatCacheMap.get(precision);
+                if (numberFormat == null) {
+                    numberFormat = new DecimalFormat("0"); //$NON-NLS-1$
+                    numberFormat.setMinimumFractionDigits(precision);
+                    numberFormat.setMaximumFractionDigits(precision);
+                    formatCacheMap.put(precision, numberFormat);
+                }
+                return numberFormat.format(numValue.doubleValue());
             }
 
         case COMPACT:

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
@@ -513,36 +513,25 @@ public class VTypeHelper {
             double dValue = numValue.doubleValue();
             if (((dValue > 0.0001) && (dValue < 10000))
                     || ((dValue < -0.0001) && (dValue > -10000)) || dValue == 0.0) {
-                return formatScalarNumber(FormatEnum.DECIMAL, numValue, precision == -1 ? 4
-                        : precision);
+                return formatScalarNumber(FormatEnum.DECIMAL, numValue, handleUnsetPrecision(precision));
             } else {
-                return formatScalarNumber(FormatEnum.EXP, numValue, precision == -1 ? 4 : precision);
+                return formatScalarNumber(FormatEnum.EXP, numValue, handleUnsetPrecision(precision));
             }
 
         case ENG:
             double value = numValue.doubleValue();
             if (value == 0) {
-                return formatScalarNumber(FormatEnum.EXP, numValue, precision == -1 ? 4 : precision);
+                return formatScalarNumber(FormatEnum.EXP, numValue, handleUnsetPrecision(precision));
             }
 
-            if (precision == -1 && numValue instanceof Display) {
-                precision = ((Display) numValue).getFormat().getMinimumFractionDigits();
-            }
-            if (precision == -1)
-                precision = DEFAULT_PRECISION;
-
+            precision = getPrecision(numValue, precision);
             double log10 = Math.log10(Math.abs(value));
             int power = 3 * (int) Math.floor(log10 / 3);
             return String.format("%." + precision + "fE%d", value / Math.pow(10, power), power);
 
         case EXP:
-            if (precision == -1 && numValue instanceof Display) {
-                precision = ((Display) numValue).getFormat().getMinimumFractionDigits();
-            }
-            if (precision == -1)
-                precision = DEFAULT_PRECISION;
-
             // Assert positive precision
+            precision = getPrecision(numValue, precision);
             precision = Math.abs(precision);
             // Exponential notation identified as 'negative' precision in cached
             numberFormat = formatCacheMap.get(-precision);
@@ -556,6 +545,7 @@ public class VTypeHelper {
                 formatCacheMap.put(-precision, numberFormat);
             }
             return numberFormat.format(numValue.doubleValue());
+
         case HEX:
             return HEX_PREFIX + Integer.toHexString(numValue.intValue()).toUpperCase();
         case HEX64:
@@ -565,6 +555,28 @@ public class VTypeHelper {
         }
     }
 
+    /** Convert an unset precision to the default value
+     *
+     * @param precision
+     * @return
+     */
+    private static int handleUnsetPrecision(int precision) {
+        return (precision == UNSET_PRECISION) ? DEFAULT_PRECISION : precision;
+    }
+
+    /** Convert an unset precision to the correct display precision or
+     *  default value
+     *
+     * @param numValue
+     * @param precision
+     * @return
+     */
+    private static int getPrecision(Number numValue, int precision) {
+        if (precision == UNSET_PRECISION && numValue instanceof Display) {
+            precision = ((Display) numValue).getFormat().getMinimumFractionDigits();
+        }
+        return handleUnsetPrecision(precision);
+    }
 
     private static double[] ListNumberToDoubleArray(ListNumber listNumber) {
         Object wrappedArray = CollectionNumbers.wrappedArray(listNumber);

--- a/applications/opibuilder/opibuilder-plugins/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/pom.xml
@@ -11,6 +11,7 @@
   <packaging>pom</packaging>
   <modules>
     <module>org.csstudio.simplepv</module>
+    <module>org.csstudio.simplepv.test</module>
     <module>org.csstudio.simplepv.pvmanager</module>
     <module>org.csstudio.simplepv.pvmanager.test</module>
     <module>org.csstudio.simplepv.testutil</module>


### PR DESCRIPTION
Adds support for an "engineering" format for Text widgets (i.e. exponent is power-of-three).
Needed for EDM conversion where this is used extensively