### PR TITLE
Issue 1854 - Databrowser axis behaviour

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlotListener.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlotListener.java
@@ -21,6 +21,9 @@ public interface RTPlotListener<XTYPE extends Comparable<XTYPE>>
     /** Invoked when the Y axis range has changed */
     default public void changedYAxis(YAxis<XTYPE> y_axis) {};
 
+    /** Invoked when auto scale is disabled by user interaction */
+    default public void changedAutoScale(YAxis<XTYPE> y_axis) {};
+
     /** Invoked when Annotations have been changed */
     default public void changedAnnotations() {};
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -910,6 +910,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                     // we can use it later to create an un-doable action.
                     pre_pan_auto_scale = axis.isAutoscale();
                     axis.lazySetAutoScale(false);
+                    fireAutoScaleChange(axis);
                     return;
                 }
             }
@@ -918,6 +919,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                 for (YAxisImpl<XTYPE> axis : y_axes) {
                     pre_pan_auto_scales.push(axis.isAutoscale());
                     axis.lazySetAutoScale(false);
+                    fireAutoScaleChange(axis);
                 }
             }
             else if (x_axis.getBounds().contains(current))
@@ -1082,10 +1084,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                     Arrays.asList(y_axis),
                     Arrays.asList(mouse_start_y_ranges.get(mouse_y_axis)),
                     Arrays.asList(y_axis.getValueRange())));
-            if(pre_pan_auto_scale) {
-                y_axis.lazySetAutoScale(false);
-                fireAutoScaleChange(y_axis);
-            }
+            y_axis.lazySetAutoScale(false);
             fireYAxisChange(y_axis);
             mouse_mode = MouseMode.PAN;
         }
@@ -1103,7 +1102,6 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             fireXAxisChange();
             for (YAxisImpl<XTYPE> axis : y_axes) {
                 axis.lazySetAutoScale(false);
-                fireAutoScaleChange(axis);
                 fireYAxisChange(axis);
             }
             mouse_mode = MouseMode.PAN;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1146,12 +1146,16 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                 // Mouse 'y' increases going _down_ the screen
                 final List<AxisRange<Double>> original_y_ranges = new ArrayList<>();
                 final List<AxisRange<Double>> new_y_ranges = new ArrayList<>();
+                final List<Boolean> original_autoscale_values = new ArrayList<>();
+                final List<Boolean> new_autoscale_values = new ArrayList<>();
                 high = Math.min(start.y, current.y);
                 low = Math.max(start.y, current.y);
                 for (YAxisImpl<XTYPE> axis : y_axes)
                 {
                     original_y_ranges.add(axis.getValueRange());
                     new_y_ranges.add(new AxisRange<Double>(axis.getValue(low), axis.getValue(high)));
+                    original_autoscale_values.add(axis.isAutoscale());
+                    new_autoscale_values.add(Boolean.FALSE);
                 }
                 undo.execute(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_In, x_axis, original_x_range, new_x_range, y_axes, original_y_ranges, new_y_ranges));
             }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -964,15 +964,20 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                 // .. and Y axes
                 final List<AxisRange<Double>> old_range = new ArrayList<>(y_axes.size()),
                                               new_range = new ArrayList<>(y_axes.size());
+                final List<Boolean> original_autoscale = new ArrayList<>(y_axes.size()),
+                                    new_autoscale = new ArrayList<>(y_axes.size());
                 for (YAxisImpl<XTYPE> axis : y_axes)
                 {
+                      original_autoscale.add(axis.isAutoscale());
+                      new_autoscale.add(Boolean.FALSE);
                       old_range.add(axis.getValueRange());
                       axis.zoom(current.y, ZOOM_FACTOR);
                       new_range.add(axis.getValueRange());
                       fireYAxisChange(axis);
                 }
                 undo.execute(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_Out,
-                        x_axis, orig_x, x_axis.getValueRange(), y_axes, old_range, new_range));
+                        x_axis, orig_x, x_axis.getValueRange(), y_axes, old_range, new_range,
+                        original_autoscale, new_autoscale));
             }
             else
             {   // Zoom out of Y axis

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1168,7 +1168,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                     original_autoscale_values.add(axis.isAutoscale());
                     new_autoscale_values.add(Boolean.FALSE);
                 }
-                undo.execute(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_In, x_axis, original_x_range, new_x_range, y_axes, original_y_ranges, new_y_ranges));
+                undo.execute(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_In, x_axis, original_x_range, new_x_range, y_axes, original_y_ranges, new_y_ranges, original_autoscale_values, new_autoscale_values));
             }
             mouse_mode = MouseMode.ZOOM_IN;
         }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -964,10 +964,10 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                 x_axis.zoom(current.x, ZOOM_FACTOR);
                 fireXAxisChange();
                 // .. and Y axes
-                final List<AxisRange<Double>> old_range = new ArrayList<>(y_axes.size()),
-                                              new_range = new ArrayList<>(y_axes.size());
-                final List<Boolean> original_autoscale = new ArrayList<>(y_axes.size()),
-                                    new_autoscale = new ArrayList<>(y_axes.size());
+                final List<AxisRange<Double>> old_range = new ArrayList<>(y_axes.size());
+                final List<AxisRange<Double>> new_range = new ArrayList<>(y_axes.size());
+                final List<Boolean> original_autoscale = new ArrayList<>(y_axes.size());
+                final List<Boolean> new_autoscale = new ArrayList<>(y_axes.size());
                 for (YAxisImpl<XTYPE> axis : y_axes)
                 {
                       original_autoscale.add(axis.isAutoscale());
@@ -996,7 +996,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                                 Arrays.asList(axis),
                                 Arrays.asList(orig),
                                 Arrays.asList(axis.getValueRange()),
-                                Arrays.asList(original_autoscale), Arrays.asList(Boolean.FALSE)));
+                                Arrays.asList(original_autoscale),
+                                Arrays.asList(Boolean.FALSE)));
                         break;
                     }
             }
@@ -1095,7 +1096,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                     Arrays.asList(y_axis),
                     Arrays.asList(mouse_start_y_ranges.get(mouse_y_axis)),
                     Arrays.asList(y_axis.getValueRange()),
-                    pre_pan_auto_scales, new_autoscales));
+                    pre_pan_auto_scales,
+                    new_autoscales));
             pre_pan_auto_scales = new Stack<Boolean>();  // Clear cache of autoscales
             fireYAxisChange(y_axis);
             mouse_mode = MouseMode.PAN;
@@ -1110,7 +1112,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             Collections.fill(new_autoscales, Boolean.FALSE);
             undo.add(new ChangeAxisRanges<XTYPE>(this, Messages.Pan,
                     x_axis, mouse_start_x_range, x_axis.getValueRange(),
-                    y_axes, mouse_start_y_ranges, current_y_ranges, pre_pan_auto_scales, new_autoscales));
+                    y_axes, mouse_start_y_ranges, current_y_ranges,
+                    pre_pan_auto_scales, new_autoscales));
             pre_pan_auto_scales = new Stack<Boolean>();  // Clear cache of autoscales
             fireXAxisChange();
             for (YAxisImpl<XTYPE> axis : y_axes)
@@ -1140,7 +1143,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                         Arrays.asList(axis),
                         Arrays.asList(axis.getValueRange()),
                         Arrays.asList(new AxisRange<Double>(axis.getValue(low), axis.getValue(high))),
-                        Arrays.asList(axis.isAutoscale()), Arrays.asList(Boolean.FALSE)));
+                        Arrays.asList(axis.isAutoscale()),
+                        Arrays.asList(Boolean.FALSE)));
             }
             mouse_mode = MouseMode.ZOOM_IN;
         }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -914,9 +914,11 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                     return;
                 }
             }
-            if (plot_area.getBounds().contains(current)) {
+            if (plot_area.getBounds().contains(current))
+            {
                 mouse_mode = MouseMode.PAN_PLOT;
-                for (YAxisImpl<XTYPE> axis : y_axes) {
+                for (YAxisImpl<XTYPE> axis : y_axes)
+                {
                     pre_pan_auto_scales.push(axis.isAutoscale());
                     axis.setAutoscale(false);
                     fireAutoScaleChange(axis);

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -975,17 +975,21 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                         x_axis, orig_x, x_axis.getValueRange(), y_axes, old_range, new_range));
             }
             else
-            {
+            {   // Zoom out of Y axis
                 for (YAxisImpl<XTYPE> axis : y_axes)
                     if (axis.getBounds().contains(current))
                     {
                         final AxisRange<Double> orig = axis.getValueRange();
+                        final Boolean original_autoscale = axis.isAutoscale();
+                        axis.setAutoscale(false);
+                        fireAutoScaleChange(axis);
                         axis.zoom(current.y, ZOOM_FACTOR);
                         fireYAxisChange(axis);
                         undo.add(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_Out_Y,
                                 Arrays.asList(axis),
                                 Arrays.asList(orig),
-                                Arrays.asList(axis.getValueRange())));
+                                Arrays.asList(axis.getValueRange()),
+                                Arrays.asList(original_autoscale), Arrays.asList(Boolean.FALSE)));
                         break;
                     }
             }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1209,4 +1209,10 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         for (RTPlotListener<XTYPE> listener : listeners)
             listener.changedToolbar(show);
     }
+
+	public void fireAutoScaleChange(YAxisImpl<XTYPE> axis)
+	{
+        for (RTPlotListener<XTYPE> listener : listeners)
+            listener.changedAutoScale(axis);
+	}
 }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Stack;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -154,7 +155,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     private List<AxisRange<Double>> mouse_start_y_ranges = new ArrayList<>();
     private int mouse_y_axis = -1;
     private boolean pre_pan_auto_scale = false;
-    private List<Boolean> pre_pan_auto_scales = new ArrayList<Boolean>();
+    private Stack<Boolean> pre_pan_auto_scales = new Stack<Boolean>();
 
     // Annotation-related info. If mouse_annotation is set, the rest should be set.
     private Optional<AnnotationImpl<XTYPE>> mouse_annotation = Optional.empty();
@@ -915,7 +916,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             if (plot_area.getBounds().contains(current)) {
                 mouse_mode = MouseMode.PAN_PLOT;
                 for (YAxisImpl<XTYPE> axis : y_axes) {
-                    pre_pan_auto_scales.add(axis.isAutoscale());
+                    pre_pan_auto_scales.push(axis.isAutoscale());
                     axis.lazySetAutoScale(false);
                 }
             }
@@ -1094,7 +1095,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             List<AxisRange<Double>> current_y_ranges = new ArrayList<>();
             for (YAxisImpl<XTYPE> axis : y_axes) {
                 current_y_ranges.add(axis.getValueRange());
-                axis.lazySetAutoScale(pre_pan_auto_scales.remove(pre_pan_auto_scales.size() - 1));
+                axis.lazySetAutoScale(pre_pan_auto_scales.pop());
             }
             undo.add(new ChangeAxisRanges<XTYPE>(this, Messages.Pan,
                     x_axis, mouse_start_x_range, x_axis.getValueRange(),

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1128,7 +1128,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
                 undo.execute(new ChangeAxisRanges<XTYPE>(this, Messages.Zoom_In_Y,
                         Arrays.asList(axis),
                         Arrays.asList(axis.getValueRange()),
-                        Arrays.asList(new AxisRange<Double>(axis.getValue(low), axis.getValue(high)))));
+                        Arrays.asList(new AxisRange<Double>(axis.getValue(low), axis.getValue(high))),
+                        Arrays.asList(axis.isAutoscale()), Arrays.asList(Boolean.FALSE)));
             }
             mouse_mode = MouseMode.ZOOM_IN;
         }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/YAxisImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/YAxisImpl.java
@@ -131,6 +131,16 @@ public class YAxisImpl<XTYPE extends Comparable<XTYPE>> extends NumericAxis impl
         requestRefresh();
     }
 
+    /** Configure the axis to auto scale or not, but
+     *  don't update the listeners.
+     *
+     * @param do_autoscale
+     */
+    public void lazySetAutoScale(boolean do_autoscale)
+    {
+        autoscale = do_autoscale;
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isAutoscale()

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/YAxisImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/YAxisImpl.java
@@ -131,16 +131,6 @@ public class YAxisImpl<XTYPE extends Comparable<XTYPE>> extends NumericAxis impl
         requestRefresh();
     }
 
-    /** Configure the axis to auto scale or not, but
-     *  don't update the listeners.
-     *
-     * @param do_autoscale
-     */
-    public void lazySetAutoScale(boolean do_autoscale)
-    {
-        autoscale = do_autoscale;
-    }
-
     /** {@inheritDoc} */
     @Override
     public boolean isAutoscale()

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
@@ -157,8 +157,10 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
     public void undo()
     {
         if (x_axis != null)
+        {
             if (x_axis.setValueRange(original_x_range.getLow(), original_x_range.getHigh()))
                 plot.fireXAxisChange();
+        }
         if (yaxes != null)
         {
             setAutoscale(original_autoscale);

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
@@ -122,7 +122,14 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
             final AxisRange<Double> range = ranges.get(i);
             final YAxisImpl<XTYPE> axis = yaxes.get(i);
             if (axis.setValueRange(range.getLow(), range.getHigh()))
+            {
+                if (axis.isAutoscale())
+                {
+                    axis.setAutoscale(false);
+                    plot.fireAutoScaleChange(axis);
+                }
                 plot.fireYAxisChange(axis);
+            }
         }
     }
 }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
@@ -159,7 +159,8 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
         if (x_axis != null)
             if (x_axis.setValueRange(original_x_range.getLow(), original_x_range.getHigh()))
                 plot.fireXAxisChange();
-        if (yaxes != null) {
+        if (yaxes != null)
+        {
             setAutoscale(original_autoscale);
             setRange(original_yranges);
         }
@@ -176,7 +177,8 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
         }
     }
 
-    private void setAutoscale(List<Boolean> autoscales) {
+    private void setAutoscale(List<Boolean> autoscales)
+    {
         if(autoscales != null)
             for (int i=0; i<yaxes.size(); ++i)
             {

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
@@ -68,6 +68,11 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
                 throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + original_y_ranges.size() + " orig. ranges");
             if (y_axes.size() != new_y_ranges.size())
                 throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + new_y_ranges.size() + " new ranges");
+
+            if (original_autoscale != null && y_axes.size() != original_autoscale.size())
+                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + original_autoscale.size() + " original autoscale");
+            if (new_autoscale != null && y_axes.size() != new_autoscale.size())
+                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + new_autoscale.size() + " new autoscale");
         }
     }
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/undo/ChangeAxisRanges.java
@@ -7,9 +7,7 @@
  ******************************************************************************/
 package org.csstudio.swt.rtplot.undo;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.csstudio.swt.rtplot.Axis;
 import org.csstudio.swt.rtplot.AxisRange;
@@ -29,6 +27,49 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
     final private List<AxisRange<Double>> original_yranges;
     final private List<AxisRange<Double>> new_yranges;
     final private List<Boolean> original_autoscale;
+    final private List<Boolean> new_autoscale;
+
+    /** @param plot Plot
+     *  @param name Name of the action
+     *  @param x_axis X Axis or <code>null</code>
+     *  @param original_x_range Original ..
+     *  @param new_x_range .. and new X range, or <code>null</code>
+     *  @param y_axes Y Axes or <code>null</code>
+     *  @param original_y_ranges Original
+     *  @param new_y_ranges .. and new value ranges, or <code>null</code>
+     *  @param original_autoscale Original auto-scale values, or <code>null</code>
+     *  @param new_autoscale New auto-scale values, or <code>null</null>
+     */
+    public ChangeAxisRanges(final Plot<XTYPE> plot,
+            final String name,
+            final Axis<XTYPE> x_axis,
+            final AxisRange<XTYPE> original_x_range,
+            final AxisRange<XTYPE> new_x_range,
+            final List<YAxisImpl<XTYPE>> y_axes,
+            final List<AxisRange<Double>> original_y_ranges,
+            final List<AxisRange<Double>> new_y_ranges,
+            final List<Boolean> original_autoscale,
+            final List<Boolean> new_autoscale)
+    {
+        super(name);
+        this.plot = plot;
+        this.x_axis = x_axis;
+        this.original_x_range = original_x_range;
+        this.new_x_range = new_x_range;
+        this.yaxes = y_axes;
+        this.original_yranges = original_y_ranges;
+        this.new_yranges = new_y_ranges;
+        this.original_autoscale = original_autoscale;
+        this.new_autoscale = new_autoscale;
+
+        if (yaxes != null)
+        {
+            if (y_axes.size() != original_y_ranges.size())
+                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + original_y_ranges.size() + " orig. ranges");
+            if (y_axes.size() != new_y_ranges.size())
+                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + new_y_ranges.size() + " new ranges");
+        }
+    }
 
     /** @param plot Plot
      *  @param name Name of the action
@@ -48,24 +89,7 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
             final List<AxisRange<Double>> original_y_ranges,
             final List<AxisRange<Double>> new_y_ranges)
     {
-        super(name);
-        this.plot = plot;
-        this.x_axis = x_axis;
-        this.original_x_range = original_x_range;
-        this.new_x_range = new_x_range;
-        this.yaxes = y_axes;
-        this.original_yranges = original_y_ranges;
-        this.new_yranges = new_y_ranges;
-        if (yaxes != null)
-        {
-            this.original_autoscale = y_axes.stream().map(YAxisImpl<XTYPE>::isAutoscale).collect(Collectors.toList());
-            if (y_axes.size() != original_y_ranges.size())
-                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + original_y_ranges.size() + " orig. ranges");
-            if (y_axes.size() != new_y_ranges.size())
-                throw new IllegalArgumentException(y_axes.size() + " Y axes, but " + new_y_ranges.size() + " new ranges");
-        }
-        else
-            this.original_autoscale = Collections.<Boolean>emptyList();
+        this(plot, name, x_axis, original_x_range, new_x_range, y_axes, original_y_ranges, new_y_ranges, null, null);
     }
 
     /** @param plot Plot
@@ -79,7 +103,7 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
             final AxisRange<XTYPE> original_x_range,
             final AxisRange<XTYPE> new_x_range)
     {
-        this(plot, name, x_axis, original_x_range, new_x_range, null, null, null);
+        this(plot, name, x_axis, original_x_range, new_x_range, null, null, null, null, null);
     }
 
     /** @param plot Plot
@@ -93,9 +117,26 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
             final List<AxisRange<Double>> original_y_ranges,
             final List<AxisRange<Double>> new_y_ranges)
     {
-        this(plot, name, null, null, null, y_axes, original_y_ranges, new_y_ranges);
+        this(plot, name, null, null, null, y_axes, original_y_ranges, new_y_ranges, null, null);
     }
 
+    /** @param plot Plot
+     *  @param name Name of the action
+     *  @param y_axes Y Axes or <code>null</code>
+     *  @param original_y_ranges Original
+     *  @param new_y_ranges .. and new value ranges, or <code>null</code>
+     *  @param original_autoscale Original auto-scale values, or <code>null</code>
+     *  @param new_autoscale New auto-scale values, or <code>null</null>
+     */
+    public ChangeAxisRanges(final Plot<XTYPE> plot, final String name,
+            final List<YAxisImpl<XTYPE>> y_axes,
+            final List<AxisRange<Double>> original_y_ranges,
+            final List<AxisRange<Double>> new_y_ranges,
+            final List<Boolean> original_autoscale,
+            final List<Boolean> new_autoscale)
+    {
+        this(plot, name, null, null, null, y_axes, original_y_ranges, new_y_ranges, original_autoscale, new_autoscale);
+    }
 
     @Override
     public void run()
@@ -106,30 +147,21 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
                 plot.fireXAxisChange();
         }
         if (yaxes != null)
+        {
+            setAutoscale(new_autoscale);
             setRange(new_yranges);
+        }
     }
 
     @Override
     public void undo()
     {
         if (x_axis != null)
-        {
             if (x_axis.setValueRange(original_x_range.getLow(), original_x_range.getHigh()))
                 plot.fireXAxisChange();
-        }
-        if (yaxes != null)
-        {
+        if (yaxes != null) {
+            setAutoscale(original_autoscale);
             setRange(original_yranges);
-            for(int i=0; i<yaxes.size(); i++)
-            {
-                YAxisImpl<XTYPE> axis = yaxes.get(i);
-                boolean autoscale = original_autoscale.get(i);
-                if(axis.isAutoscale() != autoscale)
-                {
-                    axis.setAutoscale(autoscale);
-                    plot.fireAutoScaleChange(axis);
-                }
-            }
         }
     }
 
@@ -140,14 +172,18 @@ public class ChangeAxisRanges<XTYPE extends Comparable<XTYPE>> extends UndoableA
             final AxisRange<Double> range = ranges.get(i);
             final YAxisImpl<XTYPE> axis = yaxes.get(i);
             if (axis.setValueRange(range.getLow(), range.getHigh()))
-            {
-                if (axis.isAutoscale())
-                {
-                    axis.setAutoscale(false);
-                    plot.fireAutoScaleChange(axis);
-                }
                 plot.fireYAxisChange(axis);
-            }
         }
+    }
+
+    private void setAutoscale(List<Boolean> autoscales) {
+        if(autoscales != null)
+            for (int i=0; i<yaxes.size(); ++i)
+            {
+                final Boolean autoscale = autoscales.get(i);
+                final YAxisImpl<XTYPE> axis = yaxes.get(i);
+                axis.setAutoscale(autoscale);
+                plot.fireAutoScaleChange(axis);
+            }
     }
 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/ChangeAxisConfigCommand.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/ChangeAxisConfigCommand.java
@@ -71,13 +71,13 @@ public class ChangeAxisConfigCommand extends UndoableAction
             axis.setOnRight(config.isOnRight());
         if (! axis.getColor().equals(config.getColor()))
             axis.setColor(config.getColor());
+        if (axis.isAutoScale() != config.isAutoScale())
+            axis.setAutoScale(config.isAutoScale());
         if (axis.getMin() != config.getMin()  ||
             axis.getMax() != config.getMax())
             axis.setRange(config.getMin(), config.getMax());
         if (axis.isGridVisible() != config.isGridVisible())
             axis.setGridVisible(config.isGridVisible());
-        if (axis.isAutoScale() != config.isAutoScale())
-            axis.setAutoScale(config.isAutoScale());
         if (axis.isLogScale() != config.isLogScale())
             axis.setLogScale(config.isLogScale());
         if (axis.getLabelFont().equals(config.getLabelFont()))

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -387,6 +387,14 @@ public class Controller
             {
                 model.setLegendVisible(visible);
             }
+
+            @Override
+            public void autoScaleChanged(int index, boolean autoScale)
+            {
+                final AxisConfig axis = model.getAxis(index);
+                if (axis != null)
+                    display.asyncExec(() -> axis.setAutoScale(autoScale));
+            }
         });
 
 

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -144,6 +144,13 @@ public class ModelBasedPlot
             {
                 listener.ifPresent((l) -> l.changedLegend(visible));
             }
+
+            @Override
+            public void changedAutoScale(final YAxis<Instant> y_axis)
+            {
+                final int index = plot.getYAxes().indexOf(y_axis);
+                listener.ifPresent((l) -> l.autoScaleChanged(index, y_axis.isAutoscale()));
+            }
         });
 
         hookDragAndDrop(plot);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/PlotListener.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/PlotListener.java
@@ -70,4 +70,7 @@ public interface PlotListener
 
     /** Plot legend displayed or hidden */
     public void changedLegend(boolean visible);
+
+    /** Auto scale modified by user interaction with plot */
+    public void autoScaleChanged(int index, boolean autoScale);
 }


### PR DESCRIPTION
Add's functionality to disable auto-scale when panning and zooming on a data browser plot.