### PR TITLE
Remove tab characters

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1252,9 +1252,9 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             listener.changedToolbar(show);
     }
 
-	public void fireAutoScaleChange(YAxisImpl<XTYPE> axis)
-	{
+    public void fireAutoScaleChange(YAxisImpl<XTYPE> axis)
+    {
         for (RTPlotListener<XTYPE> listener : listeners)
             listener.changedAutoScale(axis);
-	}
+    }
 }


### PR DESCRIPTION
Jenkins build failed, presumably due to high priority check style warnings.