### PR TITLE
Allow 'edit embedded opi' in run or edit mode.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -24,7 +24,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.simplepv;bundle-version="1.0.0",
  org.diirt.util;bundle-version="0.3.2",
  org.csstudio.csdata;bundle-version="3.2.0",
- org.jdom
+ org.jdom,
+ org.eclipse.ui.ide,
+ org.eclipse.core.resources,
+ org.eclipse.core.filesystem
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.csstudio.opibuilder.widgets,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/plugin.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/plugin.xml
@@ -693,5 +693,39 @@
             typeId="org.csstudio.opibuilder.widgets.groupingContainer">
       </graphicalFeedbackFactory>
    </extension>
-
+      <extension
+         point="org.eclipse.ui.commands">
+      <command
+            description="Open embedded OPI in editor"
+            id="org.csstudio.opibuilder.commands.editembeddedopi"
+            name="Edit Embedded OPI">
+      </command>
+      </extension>
+            <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+         <command
+               commandId="org.csstudio.opibuilder.commands.editembeddedopi"
+               label="Edit Embedded OPI"
+               style="push">
+            <visibleWhen>
+              <with variable="activeMenuSelection">
+                <iterate ifEmpty="false">
+                  <adapt type="org.csstudio.opibuilder.widgets.editparts.LinkingContainerEditpart">
+                  </adapt>
+                </iterate>
+              </with>
+            </visibleWhen>
+         </command>
+      </menuContribution>
+   </extension>
+         <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.csstudio.opibuilder.widgets.actions.EditEmbeddedOPIHandler"
+            commandId="org.csstudio.opibuilder.commands.editembeddedopi">
+      </handler>
+   </extension>
 </plugin>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/plugin.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/plugin.xml
@@ -709,6 +709,7 @@
          <command
                commandId="org.csstudio.opibuilder.commands.editembeddedopi"
                label="Edit Embedded OPI"
+               icon="platform:/plugin/org.csstudio.opibuilder.editor/icons/edit.gif"
                style="push">
             <visibleWhen>
               <with variable="activeMenuSelection">

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/EditEmbeddedOPIHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/EditEmbeddedOPIHandler.java
@@ -40,7 +40,7 @@ public class EditEmbeddedOPIHandler extends AbstractHandler implements IHandler 
         IPath path = null;
         LinkingContainerEditpart linkingContainer = null;
 
-        ISelection selection = HandlerUtil.getCurrentSelection(event);
+        ISelection selection = HandlerUtil.getActiveMenuSelection(event);
         if (selection instanceof IStructuredSelection) {
             IStructuredSelection structuredSelection = (IStructuredSelection) selection;
             Object o = structuredSelection.getFirstElement();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/EditEmbeddedOPIHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/actions/EditEmbeddedOPIHandler.java
@@ -1,0 +1,93 @@
+package org.csstudio.opibuilder.widgets.actions;
+import org.csstudio.opibuilder.util.ErrorHandlerUtil;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.csstudio.opibuilder.widgets.editparts.LinkingContainerEditpart;
+import org.csstudio.opibuilder.widgets.model.LinkingContainerModel;
+import org.csstudio.ui.util.perspective.PerspectiveHelper;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.ide.FileStoreEditorInput;
+import org.eclipse.ui.part.FileEditorInput;
+
+
+public class EditEmbeddedOPIHandler extends AbstractHandler implements IHandler {
+
+    private static final String OPI_EDITOR_ID = "org.csstudio.opibuilder.OPIEditor"; //$NON-NLS-1$
+    private static final String OPI_EDITOR_PERSPECTIVE_ID = "org.csstudio.opibuilder.opieditor"; //$NON-NLS-1$
+
+    /** EditOPI action
+     *  - if selected part is an OPIShell open this in the main CSS window in edit mode
+     *  - if the selected part is in the CSS window  as an OPIView open as an editor
+     *  - if the selected part is in the CSS in run mode, open in edit mode
+     */
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        IPath path = null;
+        LinkingContainerEditpart linkingContainer = null;
+
+        ISelection selection = HandlerUtil.getCurrentSelection(event);
+        if (selection instanceof IStructuredSelection) {
+            IStructuredSelection structuredSelection = (IStructuredSelection) selection;
+            Object o = structuredSelection.getFirstElement();
+            if (o instanceof LinkingContainerEditpart) {
+                linkingContainer = (LinkingContainerEditpart) o;
+                path = ((LinkingContainerModel) linkingContainer.getModel()).getOPIFilePath();
+            }
+        }
+
+        if (path != null) {
+            IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+            IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+            if (window != null) {
+                IWorkbenchPage page = window.getActivePage();
+                if (page != null) {
+                    try {
+                        IEditorInput editorInput = null;
+                        // Files outside the workspace are handled differently
+                        // by Eclipse.
+                        if (!ResourceUtil.isExistingWorkspaceFile(path)
+                                && ResourceUtil.isExistingLocalFile(path)) {
+                            // IEditorInput editorInput = new
+                            // FileStoreEditorInput(file);
+                            IFileStore fileStore = EFS.getLocalFileSystem()
+                                    .getStore(file.getFullPath());
+                            editorInput = new FileStoreEditorInput(fileStore);
+                        } else {
+                            editorInput = new FileEditorInput(file);
+                        }
+                        // Need to match on both Editor ID and file to prevent
+                        // eclipse choosing an OPIRunner instance
+                        page.openEditor(editorInput, OPI_EDITOR_ID, true,
+                                IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+                        // force switch to edit perspective
+                        PerspectiveHelper.showPerspective(
+                                OPI_EDITOR_PERSPECTIVE_ID, page);
+                    } catch (PartInitException ex) {
+                        System.err.println("Error starting OPI Editor"
+                                + ex.toString());
+                        ErrorHandlerUtil.handleError(
+                                "Failed to open current OPI in editor", ex);
+                    }
+                }
+            }
+        }
+        // required return value
+        return null;
+    }
+
+}


### PR DESCRIPTION
This is still enabled in 'no-edit' mode, and it should not be present
then.

@nickbattam for discussion.