### PR TITLE
Opibuilder: add preference for whether fonts are pixel-based by default.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/preferences/OPIEditorPreferencePage.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/preferences/OPIEditorPreferencePage.java
@@ -57,6 +57,13 @@ public class OPIEditorPreferencePage extends FieldEditorPreferencePage
                                 {"Prompt", MessageDialogWithToggle.PROMPT}},
                 parent, true);
         addField(perspectiveEditor);
+        RadioGroupFieldEditor fontInPixelsEditor = new RadioGroupFieldEditor(
+                PreferencesHelper.FONT_DEFAULT_PIXELS_OR_POINTS,
+                "Default sizing for fonts", 2,
+                new String[][] {{"Points", PreferencesHelper.POINTS},
+                                {"Pixels", PreferencesHelper.PIXELS}},
+                parent, true);
+        addField(fontInPixelsEditor);
 
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/visualparts/OPIFontDialog.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/visualparts/OPIFontDialog.java
@@ -110,9 +110,8 @@ public class OPIFontDialog extends HelpTrayDialog {
         GridData gd2 = new GridData();
         gd2.grabExcessVerticalSpace = true;
         spacer2.setLayoutData(gd2);
-        Label pixelsLabel = new Label(rightComposite, SWT.NONE);
-        pixelsLabel.setText("Font size:");
         Group radioGroup = new Group(rightComposite, SWT.NONE);
+        radioGroup.setText("Font size");
         GridLayout layout = new GridLayout();
         layout.numColumns = 2;
         radioGroup.setLayout(layout);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
@@ -67,6 +67,7 @@ public class PreferencesHelper {
     public static final String DEFAULT_TO_CLASSIC_STYLE = "default_to_classic_style"; //$NON-NLS-1$
     public static final String SHOW_OPI_RUNTIME_STACKS = "show_opi_runtime_stacks"; //$NON-NLS-1$
     public static final String SWITCH_TO_OPI_EDITOR_PERSPECTIVE = "switch_to_opi_editor_perspective"; //$NON-NLS-1$
+    public static final String FONT_DEFAULT_PIXELS_OR_POINTS = "font_default_pixels_or_points";
 
     //The widgets that are hidden from palette.
     public static final String HIDDEN_WIDGETS="hidden_widgets"; //$NON-NLS-1$
@@ -85,17 +86,28 @@ public class PreferencesHelper {
     private static final char ITEM_SEPARATOR = ',';
     private static final char MACRO_SEPARATOR = '=';
 
-    final public static String DEFAULT_EMAIL_SENDER="default_email_sender"; //$NON-NLS-1$
+    public static final String DEFAULT_EMAIL_SENDER="default_email_sender"; //$NON-NLS-1$
 
-    final public static String ABOUT_SHOW_LINKS="about_show_links"; //$NON-NLS-1$
+    public static final String ABOUT_SHOW_LINKS="about_show_links"; //$NON-NLS-1$
+    public static final String PIXELS = "pixels";
+    public static final String POINTS = "points";
 
      /** @param preferenceName Preference identifier
      *  @return String from preference system, or <code>null</code>
      */
     protected static String getString(final String preferenceName)
     {
+        return getString(preferenceName, null);
+    }
+
+    /** @param preferenceName Preference identifier
+     * @param defaultValue default value
+    *  @return String from preference system, or <code>defaultValue</code> if null
+    */
+    protected static String getString(final String preferenceName, final String defaultValue)
+    {
         final IPreferencesService service = Platform.getPreferencesService();
-        return service.getString(OPIBuilderPlugin.PLUGIN_ID, preferenceName, null, null);
+        return service.getString(OPIBuilderPlugin.PLUGIN_ID, preferenceName, defaultValue, null);
     }
 
     /**Get the color file path from preference store.
@@ -191,6 +203,10 @@ public class PreferencesHelper {
     public static Integer getPulsingAlarmMajorPeriod(){
         final IPreferencesService service = Platform.getPreferencesService();
         return service.getInt(OPIBuilderPlugin.PLUGIN_ID, PULSING_ALARM_MAJOR_PERIOD, 1500, null);
+    }
+
+    public static boolean isDefaultFontSizeInPixels(){
+        return getString(FONT_DEFAULT_PIXELS_OR_POINTS, POINTS).equals(PIXELS);
     }
 
     /**Get the macros map from preference store.

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/properties/FontProperty.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/properties/FontProperty.java
@@ -161,9 +161,14 @@ public class FontProperty extends AbstractWidgetProperty {
                 } else {
                     font = MediaService.getInstance().getOPIFont(fontElement.getText());
                 }
+                // If this was serialised without a height in pixels attribute, it was from
+                // an older verison of BOY where points were assumed.  To ensure the screens are not
+                // changed when re-saved, make this explicit.
                 if (heightInPixels != null) {
                     boolean inPixels = Boolean.parseBoolean(heightInPixels);
                     font.setSizeInPixels(inPixels);
+                } else {
+                    font.setSizeInPixels(false);
                 }
                 return font;
             }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/OPIFont.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/OPIFont.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.util;
 
+import org.csstudio.opibuilder.preferences.PreferencesHelper;
 import org.csstudio.ui.util.CustomMediaFactory;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
@@ -44,12 +45,14 @@ public class OPIFont{
         this.fontName = name;
         this.rawFontData = fontData;
         preDefined = true;
+        this.sizeInPixels = PreferencesHelper.isDefaultFontSizeInPixels();
     }
 
     OPIFont(FontData fontData) {
         this.fontName = fontData.toString();
         this.rawFontData = fontData;
         preDefined = false;
+        this.sizeInPixels = PreferencesHelper.isDefaultFontSizeInPixels();
     }
 
     OPIFont(String name, FontData fontData, boolean sizeInPixels) {


### PR DESCRIPTION
Fonts loaded from XML with pixel option not specified are loaded with
pixels as false, since it means that it was loaded from an older
version of BOY where points were the only option.

Newly-created widgets will have the preference option selected.

@nickbattam 