### PR TITLE
Use pixel scalings instead of points

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/src/org/csstudio/opibuilder/converter/writer/XMLFileHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/src/org/csstudio/opibuilder/converter/writer/XMLFileHandler.java
@@ -157,7 +157,9 @@ public class XMLFileHandler {
         assertTrue(fontElement.hasAttribute("fontName"));
         assertEquals(f.getName(), fontElement.getAttribute("fontName"));
         assertTrue(fontElement.hasAttribute("height"));
-        //assertEquals(String.valueOf(f.getSize()), fontElement.getAttribute("height"));
+        assertEquals(
+                (int) (OpiFont.FONT_SCALE * f.getSize()),
+                Integer.parseInt(fontElement.getAttribute("height")));
         int s = 0;
         if (f.isItalic())
             s = s + 2;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiFont.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiFont.java
@@ -17,12 +17,13 @@ import org.w3c.dom.Element;
  */
 public class OpiFont extends OpiAttribute {
 
+    /** Scaling factor to convert EDM font sizes into BOY **/
+    static final double FONT_SCALE = 1.01;
+
     // Definitions copied from org.eclipse.swt.SWT class.
     private static final int NORMAL = 0;
     private static final int BOLD = 1 << 0;
     private static final int ITALIC = 1 << 1;
-
-    private final double fontScale = 1.01;
 
     private static Logger log = Logger.getLogger("org.csstudio.opibuilder.converter.writer.OpiFont");
 
@@ -45,7 +46,7 @@ public class OpiFont extends OpiAttribute {
 
         String fontName = f.getName();
 
-        int size = (int) (f.getSize() * fontScale);
+        int size = (int) (f.getSize() * FONT_SCALE);
         String height = String.valueOf(size);
 
         // Style conversion copied from org.eclipse.swt.SWT class.

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiFont.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiFont.java
@@ -22,7 +22,7 @@ public class OpiFont extends OpiAttribute {
     private static final int BOLD = 1 << 0;
     private static final int ITALIC = 1 << 1;
 
-    private final double fontScale = 0.76;
+    private final double fontScale = 1.01;
 
     private static Logger log = Logger.getLogger("org.csstudio.opibuilder.converter.writer.OpiFont");
 
@@ -61,6 +61,7 @@ public class OpiFont extends OpiAttribute {
         fontElement.setAttribute("fontName", fontName);
         fontElement.setAttribute("height", height);
         fontElement.setAttribute("style", style);
+        fontElement.setAttribute("pixels", "true");
 
         log.config("Written font property with attributes: " + fontName + ", " + height + ", " + style);
     }


### PR DESCRIPTION
This should make converted screens use the new pixel font sizes, which gives better behaviour on different DPI monitors.