### PR TITLE
CSS-323

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
@@ -121,6 +121,8 @@ public class OpiWriter {
                 Class<?> opiClass = Class.forName(opiClassName);
                 Constructor<?> opiConstructor = opiClass.getConstructor(Context.class, edmClass);
                 OpiWidget widget = (OpiWidget) opiConstructor.newInstance(context, e);
+                // Sort widget properties into alphabetical order as this is the order in which
+                // CS-Studio will save them. This makes diffing the xml easier.
                 sortChildNodes(widget);
             } catch (ClassNotFoundException exception) {
                 log.warning("Class not declared: " + opiClassName);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
@@ -13,13 +13,10 @@ import java.io.FileWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.IntStream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -31,7 +28,6 @@ import org.csstudio.opibuilder.converter.model.EdmException;
 import org.csstudio.opibuilder.converter.model.EdmModel;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import com.sun.org.apache.xml.internal.serialize.OutputFormat;
@@ -128,22 +124,10 @@ public class OpiWriter {
 
                 Element element = widget.widgetContext.getElement();
                 NodeList unsortedNodes = element.getChildNodes();
-                List<Node> nodes = new ArrayList<Node>();
-                for(int i=0; i<unsortedNodes.getLength(); i++) {
-                    nodes.add(unsortedNodes.item(i));
-                }
-                Collections.sort(
-                    nodes,
-                    new Comparator<Node>() {
-                        @Override
-                        public int compare(Node o1, Node o2) {
-                            return o1.getNodeName().compareTo(o2.getNodeName());
-                        }
-                    });
-                for(Node node : nodes) {
-                    element.removeChild(node);
-                    element.appendChild(node);
-                }
+                IntStream.range(0, unsortedNodes.getLength())
+                    .mapToObj(i -> unsortedNodes.item(i))
+                    .sorted((o1, o2) -> o1.getNodeName().compareTo(o2.getNodeName()))
+                    .forEach(n -> {element.removeChild(n); element.appendChild(n);});
             } catch (ClassNotFoundException exception) {
                 log.warning("Class not declared: " + opiClassName);
             } catch (Exception exception) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
@@ -13,6 +13,10 @@ import java.io.FileWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,6 +30,9 @@ import org.csstudio.opibuilder.converter.model.EdmEntity;
 import org.csstudio.opibuilder.converter.model.EdmException;
 import org.csstudio.opibuilder.converter.model.EdmModel;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import com.sun.org.apache.xml.internal.serialize.OutputFormat;
 import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
@@ -117,7 +124,26 @@ public class OpiWriter {
             try {
                 Class<?> opiClass = Class.forName(opiClassName);
                 Constructor<?> opiConstructor = opiClass.getConstructor(Context.class, edmClass);
-                opiConstructor.newInstance(context, e);
+                OpiWidget widget = (OpiWidget) opiConstructor.newInstance(context, e);
+
+                Element element = widget.widgetContext.getElement();
+                NodeList unsortedNodes = element.getChildNodes();
+                List<Node> nodes = new ArrayList<Node>();
+                for(int i=0; i<unsortedNodes.getLength(); i++) {
+                    nodes.add(unsortedNodes.item(i));
+                }
+                Collections.sort(
+                    nodes,
+                    new Comparator<Node>() {
+                        @Override
+                        public int compare(Node o1, Node o2) {
+                            return o1.getNodeName().compareTo(o2.getNodeName());
+                        }
+                    });
+                for(Node node : nodes) {
+                    element.removeChild(node);
+                    element.appendChild(node);
+                }
             } catch (ClassNotFoundException exception) {
                 log.warning("Class not declared: " + opiClassName);
             } catch (Exception exception) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiWriter.java
@@ -121,13 +121,7 @@ public class OpiWriter {
                 Class<?> opiClass = Class.forName(opiClassName);
                 Constructor<?> opiConstructor = opiClass.getConstructor(Context.class, edmClass);
                 OpiWidget widget = (OpiWidget) opiConstructor.newInstance(context, e);
-
-                Element element = widget.widgetContext.getElement();
-                NodeList unsortedNodes = element.getChildNodes();
-                IntStream.range(0, unsortedNodes.getLength())
-                    .mapToObj(i -> unsortedNodes.item(i))
-                    .sorted((o1, o2) -> o1.getNodeName().compareTo(o2.getNodeName()))
-                    .forEach(n -> {element.removeChild(n); element.appendChild(n);});
+                sortChildNodes(widget);
             } catch (ClassNotFoundException exception) {
                 log.warning("Class not declared: " + opiClassName);
             } catch (Exception exception) {
@@ -184,5 +178,18 @@ public class OpiWriter {
         } catch (Exception e) {
             throw new EdmException(EdmException.OPI_WRITER_EXCEPTION, "Error writing to file " + fileName, e);
         }
+    }
+
+    /**
+     * Sort child nodes of the current <code>widgetContext</code> into alphabetical order.
+     * @param widget The widget who's current context will be sorted.
+     */
+    private static void sortChildNodes(OpiWidget widget) {
+        Element element = widget.widgetContext.getElement();
+        NodeList unsortedNodes = element.getChildNodes();
+        IntStream.range(0, unsortedNodes.getLength())
+            .mapToObj(i -> unsortedNodes.item(i))
+            .sorted((o1, o2) -> o1.getNodeName().compareTo(o2.getNodeName()))
+            .forEach(n -> {element.removeChild(n); element.appendChild(n);});
     }
 }


### PR DESCRIPTION
Create widget properties in alphabetical order. This reduces the change set when they files are modified and then resaved in CS-Studio.

Note that there are still changes, not all widget properties are filled in by the converter and the defaults are inserted when saving from CS-Studio. Also, the root display's properties are not in alphabetical order.