### PR TITLE
Always set zoom_to_fit_all on converted panels.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiDisplay.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/OpiDisplay.java
@@ -64,6 +64,9 @@ public class OpiDisplay {
         new OpiBoolean(context, "show_grid", d.isShowGrid());
         if (d.getAttribute("gridSize").isExistInEDL())
             new OpiInt(context, "grid_space", d.getGridSize());
+
+        // Always set zoom_to_fit_all on converted panels.
+        new OpiBoolean(context, "zoom_to_fit_all", true);
     }
 
 }


### PR DESCRIPTION
For OPIShells, this allows them to zoom when the panels are expanded.

In the workbench, this zooms all widgets into the available space,
often making them small, so this is not suitable for the general
version of the converter.

@nickbattam @mfurseman 