### PR TITLE
Remove trayicon plugin a second time.

### DIFF
--- a/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
+++ b/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
@@ -128,13 +128,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.csstudio.trayicon"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-
-
 </feature>


### PR DESCRIPTION
A rare Git merge failure meant that it wasn't removed. This commit
should be required only on the integration branch.

@nickbattam 