### PR TITLE
Move diirt repository out of cs-studio profile

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -29,6 +29,7 @@
     <upload.root>s3://download.controlsystemstudio.org</upload.root>
     <download.root>http://download.controlsystemstudio.org</download.root>
     <cs-studio-central.url>${download.root}/applications/${cs-studio.version}</cs-studio-central.url>
+    <diirt.download.root>http://diirt.download.controlsystemstudio.org</diirt.download.root>
     <diirt.version>3.1.6</diirt.version>
     <skipTests>false</skipTests>
     <!-- SonarQube configuration -->
@@ -75,6 +76,21 @@
       </properties>
     </profile>
     <profile>
+        <id>diirt-site</id>
+        <activation>
+            <property>
+                <name>!diirt-disabled</name>
+            </property>
+        </activation>
+        <repositories>
+            <repository>
+                <id>diirt</id>
+                <url>${diirt.download.root}/diirt/${diirt.version}</url>
+                <layout>p2</layout>
+            </repository>
+         </repositories>
+    </profile>
+    <profile>
       <id>csstudio-composite-repo-enable</id>
       <activation>
         <property>
@@ -108,11 +124,6 @@
         </property>
       </activation>
       <repositories>
-        <repository>
-          <id>diirt</id>
-          <url>http://diirt.download.controlsystemstudio.org/diirt/${diirt.version}</url>
-          <layout>p2</layout>
-        </repository>
         <repository>
           <id>csstudio-thirdparty</id>
           <url>${download.root}/thirdparty/${cs-studio.version}</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,7 @@
     <baselineMode>fail</baselineMode>
     <upload.root>s3://download.controlsystemstudio.org</upload.root>
     <download.root>http://download.controlsystemstudio.org</download.root>
+    <diirt.download.root>http://diirt.download.controlsystemstudio.org</diirt.download.root>
     <diirt.version>3.1.6</diirt.version>
     <cs-studio-central.url>${download.root}/core/${cs-studio.version}</cs-studio-central.url>
     <skipTests>false</skipTests>
@@ -101,6 +102,21 @@
       </pluginRepositories>
     </profile>
     <profile>
+        <id>diirt-site</id>
+        <activation>
+            <property>
+                <name>!diirt-disabled</name>
+            </property>
+        </activation>
+        <repositories>
+            <repository>
+                <id>diirt</id>
+                <url>${diirt.download.root}/diirt/${diirt.version}</url>
+                <layout>p2</layout>
+            </repository>
+        </repositories>
+    </profile>
+    <profile>
       <id>cs-studio-sites</id>
       <activation>
         <property>
@@ -108,11 +124,6 @@
         </property>
       </activation>
       <repositories>
-        <repository>
-          <id>diirt</id>
-          <url>http://diirt.download.controlsystemstudio.org/diirt/${diirt.version}</url>
-          <layout>p2</layout>
-        </repository>
         <repository>
           <id>csstudio-thirdparty</id>
           <url>${download.root}/thirdparty/${cs-studio.version}</url>


### PR DESCRIPTION
@willrogers (potential) fix for build with local p2 issues.
Thoughts welcomed (same change on dls-product repo)