### PR TITLE
OPIShellSummary view: set minimum size on buttons.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
@@ -83,6 +83,7 @@ public class OPIShellSummary extends FXViewPart {
         HBox.setHgrow(summaryLabel, Priority.ALWAYS);
 
         closeAllButton = new Button("Close all");
+        closeAllButton.setMinWidth(80);
         closeAllButton.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent e) {
@@ -91,6 +92,7 @@ public class OPIShellSummary extends FXViewPart {
             }
         });
         showAllButton = new Button("Show all");
+        showAllButton.setMinWidth(80);
         showAllButton.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent e) {
@@ -159,6 +161,7 @@ public class OPIShellSummary extends FXViewPart {
                     shell.registerWithView(this);
                 }
                 Button closeButton = new Button("Close");
+                closeButton.setMinWidth(60);
                 Label titleLabel = new Label(shell.getTitle());
                 closeButton.setOnAction(new EventHandler<ActionEvent>() {
                     @Override
@@ -168,6 +171,7 @@ public class OPIShellSummary extends FXViewPart {
                     }
                 });
                 Button showButton = new Button("Show");
+                showButton.setMinWidth(60);
                 showButton.setOnAction(new EventHandler<ActionEvent>() {
                     @Override
                     public void handle(ActionEvent e) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShellSummary.java
@@ -40,6 +40,9 @@ public class OPIShellSummary extends FXViewPart {
 
     public static final String ID = "org.csstudio.opibuilder.opiShellSummary";
 
+    private static final int MIN_SHOW_HIDE_BUTTON_SIZE = 60;  //px
+    private static final int MIN_SHOW_HIDE_ALL_BUTTON_SIZE = 80;  //px
+    
     private ScrollPane scrollpane;
     private GridPane grid;
     private Scene scene;
@@ -83,7 +86,7 @@ public class OPIShellSummary extends FXViewPart {
         HBox.setHgrow(summaryLabel, Priority.ALWAYS);
 
         closeAllButton = new Button("Close all");
-        closeAllButton.setMinWidth(80);
+        closeAllButton.setMinWidth(MIN_SHOW_HIDE_ALL_BUTTON_SIZE);
         closeAllButton.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent e) {
@@ -92,7 +95,7 @@ public class OPIShellSummary extends FXViewPart {
             }
         });
         showAllButton = new Button("Show all");
-        showAllButton.setMinWidth(80);
+        showAllButton.setMinWidth(MIN_SHOW_HIDE_ALL_BUTTON_SIZE);
         showAllButton.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent e) {
@@ -161,7 +164,7 @@ public class OPIShellSummary extends FXViewPart {
                     shell.registerWithView(this);
                 }
                 Button closeButton = new Button("Close");
-                closeButton.setMinWidth(60);
+                closeButton.setMinWidth(MIN_SHOW_HIDE_BUTTON_SIZE);
                 Label titleLabel = new Label(shell.getTitle());
                 closeButton.setOnAction(new EventHandler<ActionEvent>() {
                     @Override
@@ -171,7 +174,7 @@ public class OPIShellSummary extends FXViewPart {
                     }
                 });
                 Button showButton = new Button("Show");
-                showButton.setMinWidth(60);
+                showButton.setMinWidth(MIN_SHOW_HIDE_BUTTON_SIZE);
                 showButton.setOnAction(new EventHandler<ActionEvent>() {
                     @Override
                     public void handle(ActionEvent e) {


### PR DESCRIPTION
Quite often the view is shrunk so you can't read the text on the buttons.

@nickbattam 