### PR TITLE
cs-studio #2453 (CSS-505): added response in SearchJob to cancel call

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
@@ -52,10 +52,10 @@ abstract public class SearchJob extends Job
                 final ArchiveReader reader = ArchiveRepository.getInstance().getArchiveReader(archive.getUrl());
             )
             {
-           	    if (monitor.isCanceled()) {
-           	    	monitor.done();
+                if (monitor.isCanceled()) {
+                    monitor.done();
                     return Status.CANCEL_STATUS;
-           	    }
+                }
                 monitor.subTask(archive.getName());
                 final String[] names;
                 if (pattern_is_glob)

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
@@ -52,6 +52,10 @@ abstract public class SearchJob extends Job
                 final ArchiveReader reader = ArchiveRepository.getInstance().getArchiveReader(archive.getUrl());
             )
             {
+           	    if (monitor.isCanceled()) {
+           	    	monitor.done();
+                    return Status.CANCEL_STATUS;
+           	    }
                 monitor.subTask(archive.getName());
                 final String[] names;
                 if (pattern_is_glob)


### PR DESCRIPTION
If a Data Browser search is taking a long time (e.g. searching for PV names) then the Cancel button fails to successfully cancel the search. This branch contains a modification to SearchJob to check that the job has not been cancelled, and stop executing further searches within the archivers if this is the case.