### PR TITLE
cs-studio #2456 (CSS-499): honour relative time strings

### DIFF
--- a/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
@@ -88,7 +88,7 @@ public class RelativeTime implements Cloneable
         MINUTE_TOKEN,
         SECOND_TOKEN
     };
-
+    
     /** Construct new relative time information. */
     public RelativeTime()
     {
@@ -167,6 +167,29 @@ public class RelativeTime implements Cloneable
         rel_time[MILLISECONDS] += frac_seconds * 1000; // 1000 millis per sec
         normalize();
     }
+    /** Convert RelativeTime uniquely into seconds.
+     *  @return seconds The time array converted to seconds
+     *  One year (y) converts to 365 days; by-passing the month & day multipliers
+     */
+    public long convertToSeconds()
+    {
+        final int number_time_units = 7;
+        int [] conversions = new int [] {12, 31, 24, 60, 60, 1000};
+        long seconds = 0;
+            for (int c = 0; c < number_time_units; c++) {
+                long rolling_component = rel_time[c];
+                int first_conversion_unit = c;
+                if (c == 0) {
+                    rolling_component *= 365;
+                    first_conversion_unit = 2;
+                }
+                for (int n = first_conversion_unit; n < number_time_units - 1; n++)
+                    rolling_component *= conversions[n];
+                
+                seconds += rolling_component;
+        }
+        return seconds;
+    }
 
     /** (Try to) normalize the relative time by turning 70 seconds
      *  into 1 minute, 10 seconds etc.
@@ -180,23 +203,6 @@ public class RelativeTime implements Cloneable
         // How many DAYS in a MONTH? 30?
         // leave as is
         rollover(MONTHS, 12);
-    }
-    
-    public long seconds()
-    {
-
-    	int [] conversions = new int [] {12, 31, 24, 60, 60, 1000};
-    	long seconds = 0;
-    		for (int c = 0; c < 7; c++) {
-    			long rolling_component = rel_time[c];
-        		for (int n = c; n < 6; n++)
-        			rolling_component *= conversions[n];
-        		seconds += rolling_component;
-
-    		}
-    			
-    	return seconds;
-    	
     }
 
     /** Roll one relative time field into the next bigger one

--- a/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
@@ -181,6 +181,23 @@ public class RelativeTime implements Cloneable
         // leave as is
         rollover(MONTHS, 12);
     }
+    
+    public long seconds()
+    {
+
+    	int [] conversions = new int [] {12, 31, 24, 60, 60, 1000};
+    	long seconds = 0;
+    		for (int c = 0; c < 7; c++) {
+    			long rolling_component = rel_time[c];
+        		for (int n = c; n < 6; n++)
+        			rolling_component *= conversions[n];
+        		seconds += rolling_component;
+
+    		}
+    			
+    	return seconds;
+    	
+    }
 
     /** Roll one relative time field into the next bigger one
      *  when it exceeds the limit

--- a/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/RelativeTime.java
@@ -167,6 +167,7 @@ public class RelativeTime implements Cloneable
         rel_time[MILLISECONDS] += frac_seconds * 1000; // 1000 millis per sec
         normalize();
     }
+
     /** Convert RelativeTime uniquely into seconds.
      *  @return seconds The time array converted to seconds
      *  One year (y) converts to 365 days; by-passing the month & day multipliers
@@ -176,17 +177,17 @@ public class RelativeTime implements Cloneable
         final int number_time_units = 7;
         int [] conversions = new int [] {12, 31, 24, 60, 60, 1000};
         long seconds = 0;
-            for (int c = 0; c < number_time_units; c++) {
-                long rolling_component = rel_time[c];
-                int first_conversion_unit = c;
-                if (c == 0) {
-                    rolling_component *= 365;
-                    first_conversion_unit = 2;
-                }
-                for (int n = first_conversion_unit; n < number_time_units - 1; n++)
-                    rolling_component *= conversions[n];
-                
-                seconds += rolling_component;
+        for (int c = 0; c < number_time_units; c++) {
+            long rolling_component = rel_time[c];
+            int first_conversion_unit = c;
+            if (c == 0) {
+                rolling_component *= 365;
+                first_conversion_unit = 2;
+            }
+            for (int n = first_conversion_unit; n < number_time_units - 1; n++)
+                rolling_component *= conversions[n];
+            
+            seconds += rolling_component;
         }
         return seconds;
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
@@ -26,6 +26,7 @@ import org.csstudio.apputil.macros.MacroTable;
 import org.csstudio.apputil.macros.MacroUtil;
 import org.csstudio.apputil.time.PeriodFormat;
 import org.csstudio.apputil.time.RelativeTime;
+import org.csstudio.apputil.time.RelativeTimeParser;
 import org.csstudio.apputil.time.StartEndTimeParser;
 import org.csstudio.archive.vtype.TimestampHelper;
 import org.csstudio.swt.rtplot.util.RGBFactory;
@@ -703,6 +704,34 @@ public class Model
     {
         if (scroll_enabled)
             return new RelativeTime(-TimeDuration.toSecondsDouble(time_span)).toString();
+        else
+            return TimestampHelper.format(getStartTime());
+    }
+
+    /** @return String representation of start time. While scrolling, this is
+     *          a relative time (given by the alt_spec_string, if equivalent to time_span time), 
+     *          otherwise an absolute date/time.
+     */
+    synchronized public String getStartSpecification(String alt_spec_string)
+    {
+        if (scroll_enabled) {
+            RelativeTime spec_relative_time = new RelativeTime(-TimeDuration.toSecondsDouble(time_span));
+            try {
+                RelativeTime alt_spec_relative_time = RelativeTimeParser.parse(alt_spec_string).getRelativeTime();
+                long spec_relative_time_S = spec_relative_time.convertToSeconds();
+                long alt_spec_relative_time_S = alt_spec_relative_time.convertToSeconds();
+                final Boolean isSame = spec_relative_time_S == alt_spec_relative_time_S;
+                if (isSame)
+                        return alt_spec_string;
+                else
+                        return spec_relative_time.toString();
+            }
+            catch (Exception ex)
+            {
+            // Text invalid
+                return spec_relative_time.toString();
+            }
+        }   
         else
             return TimestampHelper.format(getStartTime());
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/DataBrowserPropertySheetPage.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/DataBrowserPropertySheetPage.java
@@ -171,7 +171,7 @@ public class DataBrowserPropertySheetPage extends Page
         @Override
         public void changedTimerange()
         {
-            start_time.setText(model.getStartSpecification());
+            start_time.setText(model.getStartSpecification(start_time.getText()));
             end_time.setText(model.getEndSpecification());
         }
 


### PR DESCRIPTION
If a relative time string e.g. 1 year is typed into the 'Start Time:' text edit box it is no longer converted to an equivalent, but different, string (e.g. in the example, the text stays as 1 year, rather than being updated to read 365.0 days). This is implemented by taking the user inputted relative time string and comparing the number of seconds it equates to with the normalised RelativeTime string proposed by the code currently (and used to determine the exact display definition).