### PR TITLE
 cs-studio #2467 (CSS-507): Stagger Radio Button & Auto Scale interaction

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/AxesTableHandler.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/AxesTableHandler.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import org.csstudio.swt.rtplot.undo.UndoableActionManager;
 import org.csstudio.trends.databrowser2.Activator;
 import org.csstudio.trends.databrowser2.Messages;
+import org.csstudio.trends.databrowser2.model.ArchiveRescale;
 import org.csstudio.trends.databrowser2.model.AxisConfig;
 import org.csstudio.trends.databrowser2.model.Model;
 import org.csstudio.trends.databrowser2.model.ModelListener;
@@ -146,6 +147,10 @@ public class AxesTableHandler implements IStructuredContentProvider
                 final ChangeAxisConfigCommand command =
                     new ChangeAxisConfigCommand(operations_manager, axis);
                 axis.setVisible(((Boolean)value).booleanValue());
+                if (((Boolean)value).booleanValue()) {
+                    if (axis.isAutoScale())
+                        model.setArchiveRescale(ArchiveRescale.NONE);
+                }
                 command.rememberNewConfig();
             }
         });
@@ -489,6 +494,8 @@ public class AxesTableHandler implements IStructuredContentProvider
                 final ChangeAxisConfigCommand command =
                     new ChangeAxisConfigCommand(operations_manager, axis);
                 axis.setAutoScale(((Boolean)value).booleanValue());
+                if (((Boolean) value).booleanValue() && axis.isVisible())
+                    model.setArchiveRescale(ArchiveRescale.NONE);
                 command.rememberNewConfig();
             }
         });

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/DataBrowserPropertySheetPage.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/DataBrowserPropertySheetPage.java
@@ -17,6 +17,7 @@ import org.csstudio.swt.rtplot.undo.UndoableActionManager;
 import org.csstudio.trends.databrowser2.Messages;
 import org.csstudio.trends.databrowser2.model.ArchiveDataSource;
 import org.csstudio.trends.databrowser2.model.ArchiveRescale;
+import org.csstudio.trends.databrowser2.model.AxisConfig;
 import org.csstudio.trends.databrowser2.model.FormulaItem;
 import org.csstudio.trends.databrowser2.model.Model;
 import org.csstudio.trends.databrowser2.model.ModelItem;
@@ -151,6 +152,12 @@ public class DataBrowserPropertySheetPage extends Page
                 boolean desired = i == selected;
                 if (rescales[i].getSelection() != desired)
                     rescales[i].setSelection(desired);
+            }
+            if (model.getArchiveRescale() == ArchiveRescale.STAGGER) {
+                for(AxisConfig axis_config : model.getAxes()) {
+                    if (axis_config.isVisible())
+                        axis_config.setAutoScale(false);
+                }
             }
         }
 


### PR DESCRIPTION
Without changing the existing 'Stagger' radio button behaviour ...

These changes prevent an incompatible combination of 'radio stagger' and axis auto scale being set:

- If "Perform 'stagger'" is selected - all visible axis are set to Auto-Scale OFF
- If Auto-Scale is turned ON for a visible axis - "Do nothing" is selected
- When an axis becomes visible; the radio buttons are set appropriately depending on its Auto-Scale setting
